### PR TITLE
changed evalfuncs in aero and struct problems to sorted lists

### DIFF
--- a/python/pyAero_problem.py
+++ b/python/pyAero_problem.py
@@ -280,6 +280,9 @@ areaRef=0.772893541, chordRef=0.64607, xRef=0.0, zRef=0.0, alpha=3.06, T=255.56)
                           "instead.")
             self.evalFuncs = set(kwargs['funcs'])
 
+        # we cast the set to a sorted list, so that each proc can loop over in the same order
+        self.evalFuncs = sorted(list(self.evalFuncs))
+
         # these are the possible input values
         possibleInputStates = set(['mach', 'V', 'P', 'T', 'rho', 'altitude', 'reynolds',
                                   'reynoldsLength'])

--- a/python/pyStruct_problem.py
+++ b/python/pyStruct_problem.py
@@ -75,6 +75,9 @@ class StructProblem(object):
             if self.evalFuncs is None:
                 self.evalFuncs = set(kwargs['funcs'])
 
+        # we cast the set to a sorted list, so that each proc can loop over in the same order
+        self.evalFuncs = sorted(list(self.evalFuncs))
+
         # When a solver calls its evalFunctions() it must write the
         # unique name it gives to funcNames. 
         self.funcNames = {}


### PR DESCRIPTION
Sets do not maintain order, so when we loop over the items we may go over them in different orders not just when running the code at different times, but also between procs under MPI. Python 2 uses hashes to implicitly order items so things were kept under control, but python 3's behavior is random and this caused MPI issues in pyaerostructure (there is a corresponding fix/PR there). Here we make everything into _sorted_ lists so that every proc will have the same order, every time we run the same code.