### PR TITLE
Update testflo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+os:
+  - linux
+
+branches:
+  only:
+  - master
+
+language: generic
+
+services:
+  - docker
+env:
+  global:
+    - REPO_NAME=baseclasses
+    - DOCKER_WORKING_DIR=/home/mdolabuser/repos/$REPO_NAME
+    - DOCKER_MOUNT_DIR=/home/mdolabuser/travis/$REPO_NAME
+  jobs:
+    # - DOCKER_TAG=c7-gcc-ompi-py3-latest
+    - DOCKER_TAG=c7-intel-impi-py3-latest
+    - DOCKER_TAG=u18-gcc-ompi-py2-stable
+    - DOCKER_TAG=u18-gcc-ompi-py3-latest
+    - DOCKER_TAG=u18-gcc-ompi-py3-stable
+    - DOCKER_TAG=u20-gcc-ompi-py3-latest
+    - DOCKER_TAG=u20-gcc-ompi-py3-stable
+
+before_install:
+  - docker pull mdolab/public:$DOCKER_TAG
+  # run Docker, key is we mount the current Travis directory into Docker to access content of repo
+  - docker run -t -d 
+        --name app
+        --mount "type=bind,src=$(pwd),target=$DOCKER_MOUNT_DIR"
+        mdolab/public:$DOCKER_TAG
+        /bin/bash
+
+install:
+  # We thrown away the existing repo in Docker, and copy the new one in-place
+  - docker exec -it app /bin/bash -c "rm -rf $DOCKER_WORKING_DIR && cp -r $DOCKER_MOUNT_DIR $DOCKER_WORKING_DIR"
+  - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && pip install ."
+
+script:
+  # We need to source the mdolab bashrc before running anything
+  - docker exec -it app /bin/bash -c ". \$HOME/.bashrc_mdolab && cd $DOCKER_WORKING_DIR && testflo . -v"
+
+after_script:
+  - docker rm -f app

--- a/baseclasses/BaseRegTest.py
+++ b/baseclasses/BaseRegTest.py
@@ -158,6 +158,10 @@ class BaseRegTest(object):
 
         value = value[0]
         if self.train:
+            if name in db.keys():
+                raise ValueError(
+                    "The name {} is already in the training database. Please give values UNIQUE keys.".format(name)
+                )
             db[name] = value
         else:
             self.assert_allclose(value, db[name], err_name, rtol, atol)
@@ -168,16 +172,15 @@ class BaseRegTest(object):
 
     def _add_values(self, values, name, rtol, atol, db=None, err_name=None):
         """Add values in special value format"""
-        # values = numpy.atleast_1d(values)
-        # values = values.flatten()
-        # for val in values:
-        #     self._add_value(val, *args, **kwargs)
-
         if db is None:
             db = self.db
         if err_name is None:
             err_name = name
         if self.train:
+            if name in db.keys():
+                raise ValueError(
+                    "The name {} is already in the training database. Please give values UNIQUE keys.".format(name)
+                )
             db[name] = values
         else:
             self.assert_allclose(values, db[name], err_name, rtol, atol)
@@ -185,27 +188,24 @@ class BaseRegTest(object):
     def _add_dict(self, d, dict_name, rtol, atol, db=None, err_name=None):
         """Add all values in a dictionary in sorted key order"""
 
-        if self.train:
-            self.db[dict_name] = {}
         if db is None:
             db = self.db
 
         for key in sorted(d.keys()):
-            print(dict_name, key)
-            # if msg is None:
-            #     key_msg = key
+            name = "{}: {}".format(dict_name, key)
             if err_name:
-                key_msg = err_name + ":" + dict_name + ": " + key
+                key_msg = err_name + ":" + name
             else:
-                key_msg = dict_name + ": " + key
+                key_msg = name
 
             if type(d[key]) == bool:
-                self._add_value(int(d[key]), key, rtol, atol, db=db[dict_name], err_name=key_msg)
+                self._add_value(int(d[key]), name, rtol, atol, db=db[dict_name], err_name=key_msg)
             if isinstance(d[key], dict):
                 # do some good ol' fashion recursion
-                self._add_dict(d[key], key, rtol, atol, db=db[dict_name], err_name=dict_name)
+                self._add_dict(d[key], name, rtol, atol, err_name=dict_name)
             else:
-                self._add_values(d[key], key, rtol, atol, db=db[dict_name], err_name=key_msg)
+                self._add_values(d[key], name, rtol, atol, err_name=key_msg)
+
 
 # =============================================================================
 #                         reference files I/O

--- a/baseclasses/BaseRegTest.py
+++ b/baseclasses/BaseRegTest.py
@@ -108,39 +108,39 @@ class BaseRegTest(object):
             print(s)
 
     # Add values from root only
-    def root_add_val(self, values, name, **kwargs):
+    def root_add_val(self, name, values, **kwargs):
         """Add values but only on the root proc"""
         rtol, atol = getTol(**kwargs)
         if self.rank == 0:
-            self._add_values(values, name, rtol, atol)
+            self._add_values(name, values, rtol, atol)
 
-    def root_add_dict(self, d, name, **kwargs):
+    def root_add_dict(self, name, d, **kwargs):
         """Only write from the root proc"""
         rtol, atol = getTol(**kwargs)
         if self.rank == 0:
-            self._add_dict(d, name, rtol, atol)
+            self._add_dict(name, d, rtol, atol)
 
     # Add values from all processors
-    def par_add_val(self, values, name, **kwargs):
+    def par_add_val(self, name, values, **kwargs):
         """Add value(values) from parallel process in sorted order"""
         rtol, atol = getTol(**kwargs)
         values = self.comm.gather(values)
         if self.rank == 0:
-            self._add_values(values, name, rtol, atol)
+            self._add_values(name, values, rtol, atol)
 
-    def par_add_sum(self, values, name, **kwargs):
+    def par_add_sum(self, name, values, **kwargs):
         """Add the sum of sum of the values from all processors."""
         rtol, atol = getTol(**kwargs)
         reducedSum = self.comm.reduce(numpy.sum(values))
         if self.rank == 0:
-            self._add_values(reducedSum, name, rtol, atol)
+            self._add_values(name, reducedSum, rtol, atol)
 
-    def par_add_norm(self, values, name, **kwargs):
+    def par_add_norm(self, name, values, **kwargs):
         """Add the norm across values from all processors."""
         rtol, atol = getTol(**kwargs)
         reducedSum = self.comm.reduce(numpy.sum(values ** 2))
         if self.rank == 0:
-            self._add_values(numpy.sqrt(reducedSum), name, rtol, atol)
+            self._add_values(name, numpy.sqrt(reducedSum), rtol, atol)
 
     # *****************
     # Private functions
@@ -149,7 +149,7 @@ class BaseRegTest(object):
         msg = "Failed value for: {}".format(name)
         numpy.testing.assert_allclose(actual, reference, rtol=rtol, atol=atol, err_msg=msg)
 
-    def _add_values(self, values, name, rtol, atol, db=None):
+    def _add_values(self, name, values, rtol, atol, db=None):
         """Add values in special value format"""
         if db is None:
             db = self.db
@@ -162,7 +162,7 @@ class BaseRegTest(object):
         else:
             self.assert_allclose(values, db[name], name, rtol, atol)
 
-    def _add_dict(self, d, dict_name, rtol, atol, db=None):
+    def _add_dict(self, dict_name, d, rtol, atol, db=None):
         """Add all values in a dictionary in sorted key order"""
 
         if db is None:
@@ -172,12 +172,12 @@ class BaseRegTest(object):
             name = "{}: {}".format(dict_name, key)
 
             if type(d[key]) == bool:
-                self._add_values(int(d[key]), name, rtol, atol, db=db[dict_name])
+                self._add_values(name, int(d[key]), rtol, atol, db=db[dict_name])
             if isinstance(d[key], dict):
                 # do some good ol' fashion recursion
-                self._add_dict(d[key], name, rtol, atol)
+                self._add_dict(name, d[key], rtol, atol)
             else:
-                self._add_values(d[key], name, rtol, atol)
+                self._add_values(name, d[key], rtol, atol)
 
 
 # =============================================================================

--- a/baseclasses/BaseRegTest.py
+++ b/baseclasses/BaseRegTest.py
@@ -149,12 +149,10 @@ class BaseRegTest(object):
         msg = "Failed value for: {}".format(name)
         numpy.testing.assert_allclose(actual, reference, rtol=rtol, atol=atol, err_msg=msg)
 
-    def _add_values(self, values, name, rtol, atol, db=None, err_name=None):
+    def _add_values(self, values, name, rtol, atol, db=None):
         """Add values in special value format"""
         if db is None:
             db = self.db
-        if err_name is None:
-            err_name = name
         if self.train:
             if name in db.keys():
                 raise ValueError(
@@ -162,9 +160,9 @@ class BaseRegTest(object):
                 )
             db[name] = values
         else:
-            self.assert_allclose(values, db[name], err_name, rtol, atol)
+            self.assert_allclose(values, db[name], name, rtol, atol)
 
-    def _add_dict(self, d, dict_name, rtol, atol, db=None, err_name=None):
+    def _add_dict(self, d, dict_name, rtol, atol, db=None):
         """Add all values in a dictionary in sorted key order"""
 
         if db is None:
@@ -172,18 +170,14 @@ class BaseRegTest(object):
 
         for key in sorted(d.keys()):
             name = "{}: {}".format(dict_name, key)
-            if err_name:
-                key_msg = err_name + ":" + name
-            else:
-                key_msg = name
 
             if type(d[key]) == bool:
                 self._add_values(int(d[key]), name, rtol, atol, db=db[dict_name])
             if isinstance(d[key], dict):
                 # do some good ol' fashion recursion
-                self._add_dict(d[key], name, rtol, atol, err_name=dict_name)
+                self._add_dict(d[key], name, rtol, atol)
             else:
-                self._add_values(d[key], name, rtol, atol, err_name=key_msg)
+                self._add_values(d[key], name, rtol, atol)
 
 
 # =============================================================================

--- a/baseclasses/BaseRegTest.py
+++ b/baseclasses/BaseRegTest.py
@@ -126,9 +126,7 @@ class BaseRegTest(object):
         rtol, atol = getTol(**kwargs)
         values = self.comm.gather(values)
         if self.rank == 0:
-            for i in range(len(values)):
-                print("Value(s) on processor: %d" % i)
-                self._add_values(values[i], name, rtol, atol)
+            self._add_values(values, name, rtol, atol)
 
     def par_add_sum(self, values, name, **kwargs):
         """Add the sum of sum of the values from all processors."""
@@ -217,7 +215,7 @@ class BaseRegTest(object):
 def writeRefJSON(file_name, ref):
     class NumpyEncoder(json.JSONEncoder):
         def default(self, obj):
-            """If input object is an ndarray it will be converted into a dict 
+            """If input object is an ndarray it will be converted into a dict
             holding dtype, shape and the data, base64 encoded.
             """
             if isinstance(obj, numpy.ndarray):

--- a/baseclasses/BaseRegTest.py
+++ b/baseclasses/BaseRegTest.py
@@ -224,8 +224,11 @@ def writeRefJSON(file_name, ref):
                 else:
                     obj = numpy.ascontiguousarray(obj)
                     assert obj.flags["C_CONTIGUOUS"]
-                shape = obj.shape
-                return dict(__ndarray__=obj.tolist(), dtype=str(obj.dtype), shape=shape)
+                return dict(__ndarray__=obj.tolist(), dtype=str(obj.dtype), shape=obj.shape)
+            elif isinstance(obj, numpy.integer):
+                return dict(__ndarray__=int(obj), dtype=str(obj.dtype), shape=obj.shape)
+            elif isinstance(obj, numpy.floating):
+                return dict(__ndarray__=float(obj), dtype=str(obj.dtype), shape=obj.shape)
 
             # Let the base class default method raise the TypeError
             super(NumpyEncoder, self).default(obj)

--- a/baseclasses/BaseRegTest.py
+++ b/baseclasses/BaseRegTest.py
@@ -133,39 +133,18 @@ class BaseRegTest(object):
         rtol, atol = getTol(**kwargs)
         reducedSum = self.comm.reduce(numpy.sum(values))
         if self.rank == 0:
-            self._add_value(reducedSum, name, rtol, atol)
+            self._add_values(reducedSum, name, rtol, atol)
 
     def par_add_norm(self, values, name, **kwargs):
         """Add the norm across values from all processors."""
         rtol, atol = getTol(**kwargs)
         reducedSum = self.comm.reduce(numpy.sum(values ** 2))
         if self.rank == 0:
-            self._add_value(numpy.sqrt(reducedSum), name, rtol, atol)
+            self._add_values(numpy.sqrt(reducedSum), name, rtol, atol)
 
     # *****************
     # Private functions
     # *****************
-    def _add_value(self, value, name, rtol, atol, db=None, err_name=None):
-        # We only check floats and integers
-        if db is None:
-            db = self.db
-
-        if err_name is None:
-            err_name = name
-
-        value = numpy.atleast_1d(value).flatten()
-        assert value.size == 1
-
-        value = value[0]
-        if self.train:
-            if name in db.keys():
-                raise ValueError(
-                    "The name {} is already in the training database. Please give values UNIQUE keys.".format(name)
-                )
-            db[name] = value
-        else:
-            self.assert_allclose(value, db[name], err_name, rtol, atol)
-
     def assert_allclose(self, actual, reference, name, rtol, atol):
         msg = "Failed value for: {}".format(name)
         numpy.testing.assert_allclose(actual, reference, rtol=rtol, atol=atol, err_msg=msg)
@@ -199,7 +178,7 @@ class BaseRegTest(object):
                 key_msg = name
 
             if type(d[key]) == bool:
-                self._add_value(int(d[key]), name, rtol, atol, db=db[dict_name], err_name=key_msg)
+                self._add_values(int(d[key]), name, rtol, atol, db=db[dict_name])
             if isinstance(d[key], dict):
                 # do some good ol' fashion recursion
                 self._add_dict(d[key], name, rtol, atol, err_name=dict_name)

--- a/baseclasses/BaseRegTest.py
+++ b/baseclasses/BaseRegTest.py
@@ -167,17 +167,19 @@ class BaseRegTest(object):
 
         if db is None:
             db = self.db
+        if self.train:
+            db[dict_name] = {}
+        elif dict_name not in db.keys():
+            raise ValueError("The key '{}' was not found in the reference file!")
 
         for key in sorted(d.keys()):
-            name = "{}: {}".format(dict_name, key)
-
-            if type(d[key]) == bool:
-                self._add_values(name, int(d[key]), rtol, atol, db=db[dict_name])
+            if isinstance(d[key], bool):
+                self._add_values(key, int(d[key]), rtol, atol, db=db[dict_name])
             if isinstance(d[key], dict):
                 # do some good ol' fashion recursion
-                self._add_dict(name, d[key], rtol, atol)
+                self._add_dict(key, d[key], rtol, atol, db=db[dict_name])
             else:
-                self._add_values(name, d[key], rtol, atol)
+                self._add_values(key, d[key], rtol, atol, db=db[dict_name])
 
 
 # =============================================================================

--- a/tests/test_BaseRegTest.py
+++ b/tests/test_BaseRegTest.py
@@ -1,0 +1,94 @@
+import os
+import unittest
+import copy
+import numpy as np
+from mpi4py import MPI
+from baseclasses import BaseRegTest
+from baseclasses.BaseRegTest import getTol
+
+
+comm = MPI.COMM_WORLD
+baseDir = os.path.dirname(os.path.abspath(__file__))
+root_vals = {"scalar": 1.0}
+
+root_vals_ref = copy.copy(root_vals)
+root_vals["simple dictionary"] = {"a": 1.0}
+root_vals["nested dictionary"] = {"a": {"b": 1.0, "c": 2.0}}
+root_vals_ref["simple dictionary: a"] = 1.0
+root_vals_ref["nested dictionary: a: b"] = 1.0
+root_vals_ref["nested dictionary: a: c"] = 2.0
+
+
+par_vals = {
+    "par val": [0.5, 1.5],
+    "par sum": 0.5 + 1.5,
+    "par norm": np.sqrt(2.5),
+}
+
+
+def regression_test_root(handler):
+    """
+    This function adds values from root_vals to root
+    """
+    for key, val in root_vals.items():
+        if isinstance(val, dict):
+            handler.root_add_dict(val, key)
+        elif isinstance(val, (float, int)):
+            handler.root_add_val(val, key)
+
+
+def regression_test_par(handler):
+    """
+    This function adds values in parallel
+    """
+    val = comm.rank + 0.5
+    handler.par_add_val(val, "par val")
+    handler.par_add_sum(val, "par sum")
+    handler.par_add_norm(val, "par norm")
+
+
+class TestBaseRegTest(unittest.TestCase):
+    N_PROCS = 2
+
+    def test_tol(self):
+        """
+        Test that the getTol function
+        """
+        x = 1e-1
+        y = 1e-2
+        c = 1e-3
+        d = 1e-12
+        r, a = getTol(atol=x, rtol=y)
+        self.assertEqual(a, x)
+        self.assertEqual(r, y)
+        r, a = getTol(atol=c)
+        self.assertEqual(a, c)
+        self.assertEqual(r, d)
+        r, a = getTol(rtol=c)
+        self.assertEqual(a, d)
+        self.assertEqual(r, c)
+        r, a = getTol(tol=c)
+        self.assertEqual(a, c)
+        self.assertEqual(r, c)
+
+    def test_train_then_test_root(self):
+        fileName = os.path.join(baseDir, "test_root.ref")
+        handler = BaseRegTest(fileName, train=True)
+        regression_test_root(handler)
+        handler.writeRef()
+        test_vals = handler.readRef()
+        # self.assertEqual(test_vals, root_vals_ref)
+        handler.root_print(test_vals)
+        handler.root_print(root_vals_ref)
+        handler = BaseRegTest(fileName, train=False)
+        regression_test_root(handler)
+
+    def test_train_then_test_par(self):
+        fileName = os.path.join(baseDir, "test_par.ref")
+        handler = BaseRegTest(fileName, train=True)
+        regression_test_par(handler)
+        handler.writeRef()
+        test_vals = handler.readRef()
+        self.assertEqual(test_vals, par_vals)
+        handler = BaseRegTest(fileName, train=False)
+        regression_test_par(handler)

--- a/tests/test_BaseRegTest.py
+++ b/tests/test_BaseRegTest.py
@@ -32,9 +32,9 @@ def regression_test_root(handler):
     """
     for key, val in root_vals.items():
         if isinstance(val, dict):
-            handler.root_add_dict(val, key)
+            handler.root_add_dict(key, val)
         elif isinstance(val, (float, int)):
-            handler.root_add_val(val, key)
+            handler.root_add_val(key, val)
 
 
 def regression_test_par(handler):
@@ -42,9 +42,9 @@ def regression_test_par(handler):
     This function adds values in parallel
     """
     val = comm.rank + 0.5
-    handler.par_add_val(val, "par val")
-    handler.par_add_sum(val, "par sum")
-    handler.par_add_norm(val, "par norm")
+    handler.par_add_val("par val", val)
+    handler.par_add_sum("par sum", val)
+    handler.par_add_norm("par norm", val)
 
 
 class TestBaseRegTest(unittest.TestCase):

--- a/tests/test_BaseRegTest.py
+++ b/tests/test_BaseRegTest.py
@@ -49,7 +49,7 @@ class TestBaseRegTest(unittest.TestCase):
 
     def test_tol(self):
         """
-        Test that the getTol function
+        Test that the getTol function is returning the appropriate values
         """
         x = 1e-1
         y = 1e-2

--- a/tests/test_BaseRegTest.py
+++ b/tests/test_BaseRegTest.py
@@ -1,6 +1,5 @@
 import os
 import unittest
-import copy
 import numpy as np
 from mpi4py import MPI
 from baseclasses import BaseRegTest
@@ -10,16 +9,11 @@ from baseclasses.BaseRegTest import getTol
 comm = MPI.COMM_WORLD
 baseDir = os.path.dirname(os.path.abspath(__file__))
 # this is the dictionary of values to be added
-root_vals = {"scalar": 1.0}
-root_vals_ref = copy.copy(root_vals)
-root_vals["simple dictionary"] = {"a": 1.0}
-root_vals["nested dictionary"] = {"a": {"b": 1.0, "c": 2.0}}
-# this is the dictionary of reference values
-# note that the format is different, because when we recursively add dictionaries we just modify the key
-# and flatten it, instead of storing them as nested dictionaries in JSON
-root_vals_ref["simple dictionary: a"] = 1.0
-root_vals_ref["nested dictionary: a: b"] = 1.0
-root_vals_ref["nested dictionary: a: c"] = 2.0
+root_vals = {
+    "scalar": 1.0,
+    "simple dictionary": {"a": 1.0},
+    "nested dictionary": {"a": {"b": 1.0, "c": 2.0}},
+}
 
 # this is the dictionary for parallel tests
 par_vals = {
@@ -84,9 +78,7 @@ class TestBaseRegTest(unittest.TestCase):
         regression_test_root(handler)
         handler.writeRef()
         test_vals = handler.readRef()
-        # self.assertEqual(test_vals, root_vals_ref)
-        handler.root_print(test_vals)
-        handler.root_print(root_vals_ref)
+        self.assertEqual(test_vals, root_vals)
         handler = BaseRegTest(fileName, train=False)
         regression_test_root(handler)
 

--- a/tests/test_BaseRegTest.py
+++ b/tests/test_BaseRegTest.py
@@ -9,16 +9,19 @@ from baseclasses.BaseRegTest import getTol
 
 comm = MPI.COMM_WORLD
 baseDir = os.path.dirname(os.path.abspath(__file__))
+# this is the dictionary of values to be added
 root_vals = {"scalar": 1.0}
-
 root_vals_ref = copy.copy(root_vals)
 root_vals["simple dictionary"] = {"a": 1.0}
 root_vals["nested dictionary"] = {"a": {"b": 1.0, "c": 2.0}}
+# this is the dictionary of reference values
+# note that the format is different, because when we recursively add dictionaries we just modify the key
+# and flatten it, instead of storing them as nested dictionaries in JSON
 root_vals_ref["simple dictionary: a"] = 1.0
 root_vals_ref["nested dictionary: a: b"] = 1.0
 root_vals_ref["nested dictionary: a: c"] = 2.0
 
-
+# this is the dictionary for parallel tests
 par_vals = {
     "par val": [0.5, 1.5],
     "par sum": 0.5 + 1.5,
@@ -28,7 +31,7 @@ par_vals = {
 
 def regression_test_root(handler):
     """
-    This function adds values from root_vals to root
+    This function adds values for the root proc
     """
     for key, val in root_vals.items():
         if isinstance(val, dict):
@@ -72,6 +75,10 @@ class TestBaseRegTest(unittest.TestCase):
         self.assertEqual(r, c)
 
     def test_train_then_test_root(self):
+        """
+        Test for adding values to the root, both in training and in testing
+        Also tests read/write in the process
+        """
         fileName = os.path.join(baseDir, "test_root.ref")
         handler = BaseRegTest(fileName, train=True)
         regression_test_root(handler)
@@ -84,6 +91,10 @@ class TestBaseRegTest(unittest.TestCase):
         regression_test_root(handler)
 
     def test_train_then_test_par(self):
+        """
+        Test for adding values in parallel, both in training and in testing
+        Also tests read/write in the process
+        """
         fileName = os.path.join(baseDir, "test_par.ref")
         handler = BaseRegTest(fileName, train=True)
         regression_test_par(handler)


### PR DESCRIPTION
## Purpose
This PR further updates the BaseRegTest API:
- Flipped the call signature so the various `add_values` functions take `(name, value)` instead of `(value, name)`
- Fixed a bug for saving nested dictionaries
- made read/write reference files only operate on the root proc, then broadcast to all procs
- changed `par_add` to save a single vector value after gather, instead of one scalar per proc
  - **please check that this is okay** because I didn't see any code that uses this function
- updated the Numpy JSON writer to allow int/float entries
- removed `add_value` since `add_values` can do everything
- added `raise ValueError` when duplicate keys are being added during training
- various other updates
- added a test (...for the testing module) and added travis

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Bugfix (non-breaking change which fixes an issue)
- Breaking change (non-backwards-compatible fix or feature)
- Refactoring (no functional changes, no API changes)

## Testing
I added a test which runs in parallel under testflo.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
