### PR TITLE
Add compare function when training

### DIFF
--- a/baseclasses/BaseRegTest.py
+++ b/baseclasses/BaseRegTest.py
@@ -47,7 +47,8 @@ class BaseRegTest(object):
 
         self.train = train
         if self.train:
-            self.setTrainingMode()
+            self.train = True
+            self.db = {}
         else:
             # We need to check here that the reference file exists, otherwise
             # it will hang when it tries to open it on the root proc.
@@ -67,16 +68,6 @@ class BaseRegTest(object):
     def __exit__(self, exc_type, exc_value, traceback):
         if self.train:
             self.writeRef()
-
-    def setTrainingMode(self):
-        """
-        This function is used in cases where you may need to instantiate BaseRegTest with train=False,
-        then update it to True later on (see ADflow).
-        Since this resets the database, it must be called before any values are added, otherwise
-        they will be erased.
-        """
-        self.train = True
-        self.db = {}
 
     def getRef(self):
         return self.db

--- a/baseclasses/BaseRegTest.py
+++ b/baseclasses/BaseRegTest.py
@@ -177,7 +177,7 @@ class BaseRegTest(object):
         if not self.train or (self.train and compare):
             self.assert_allclose(values, db[name], name, rtol, atol)
         else:
-            if name in db.keys() and not compare:
+            if name in db.keys():
                 raise ValueError(
                     "The name {} is already in the training database. Please give values UNIQUE keys.".format(name)
                 )

--- a/baseclasses/BaseRegTest.py
+++ b/baseclasses/BaseRegTest.py
@@ -178,8 +178,9 @@ class BaseRegTest(object):
     def _add_values(self, name, values, db=None, **kwargs):
         """
         Add values in special value format
-        If compare=True, it will compare against the database instead of adding the value
-        even in training mode. This is used for example in dot product tests.
+        If compare=True, it will compare the supplied value against an existing value
+        in the database instead of adding the value, even in training mode. This is useful
+        for example in dot product tests when comparing two values.
         """
         rtol, atol = getTol(**kwargs)
         compare = kwargs["compare"] if "compare" in kwargs else False

--- a/baseclasses/BaseRegTest.py
+++ b/baseclasses/BaseRegTest.py
@@ -45,7 +45,7 @@ class BaseRegTest(object):
 
         self.train = train
         if self.train:
-            self.db = {}
+            self.setTrainingMode()
         else:
             # We need to check here that the reference file exists, otherwise
             # it will hang when it tries to open it on the root proc.
@@ -65,6 +65,16 @@ class BaseRegTest(object):
     def __exit__(self, exc_type, exc_value, traceback):
         if self.train:
             self.writeRef()
+
+    def setTrainingMode(self):
+        """
+        This function is used in cases where you may need to instantiate BaseRegTest with train=False,
+        then update it to True later on (see ADflow).
+        Since this resets the database, it must be called before any values are added, otherwise
+        they will be erased.
+        """
+        self.train = True
+        self.db = {}
 
     def getRef(self):
         return self.db

--- a/baseclasses/BaseRegTest.py
+++ b/baseclasses/BaseRegTest.py
@@ -12,13 +12,11 @@ from contextlib import contextmanager
 
 def getTol(**kwargs):
     """
-    Returns the tolerances based on kwargs, as well as the trimmed
-    kwargs without the tolerances stored.
+    Returns the tolerances based on kwargs.
     There are two ways of specifying tolerance:
     1. pass in "tol" which will set atol = rtol = tol
     2. individually set atol and rtol.
     If any values are unspecified, the default value will be used.
-
     """
     DEFAULT_TOL = 1e-12
     if "tol" in kwargs:
@@ -47,7 +45,6 @@ class BaseRegTest(object):
 
         self.train = train
         if self.train:
-            self.train = True
             self.db = {}
         else:
             # We need to check here that the reference file exists, otherwise

--- a/baseclasses/BaseRegTest.py
+++ b/baseclasses/BaseRegTest.py
@@ -178,17 +178,17 @@ class BaseRegTest(object):
     def _add_values(self, name, values, db=None, **kwargs):
         """
         Add values in special value format
-        If check=True, it will check against the database instead of adding the value
+        If compare=True, it will compare against the database instead of adding the value
         even in training mode. This is used for example in dot product tests.
         """
         rtol, atol = getTol(**kwargs)
-        check = kwargs["check"] if "check" in kwargs else False
+        compare = kwargs["compare"] if "compare" in kwargs else False
         if db is None:
             db = self.db
-        if not self.train or (self.train and check):
+        if not self.train or (self.train and compare):
             self.assert_allclose(values, db[name], name, rtol, atol)
         else:
-            if name in db.keys() and not check:
+            if name in db.keys() and not compare:
                 raise ValueError(
                     "The name {} is already in the training database. Please give values UNIQUE keys.".format(name)
                 )

--- a/tests/test_BaseRegTest.py
+++ b/tests/test_BaseRegTest.py
@@ -55,30 +55,18 @@ class TestBaseRegTest(unittest.TestCase):
         y = 1e-2
         c = 1e-3
         d = 1e-12
-        r, a, kw = getTol(atol=x, rtol=y)
+        r, a = getTol(atol=x, rtol=y)
         self.assertEqual(a, x)
         self.assertEqual(r, y)
-        self.assertEqual(kw, {})
-        r, a, kw = getTol(atol=x, rtol=y, check=True)
-        self.assertEqual(kw, {"check": True})
-        r, a, kw = getTol(atol=c)
+        r, a = getTol(atol=c)
         self.assertEqual(a, c)
         self.assertEqual(r, d)
-        self.assertEqual(kw, {})
-        r, a, kw = getTol(atol=c, check=False)
-        self.assertEqual(kw, {"check": False})
-        r, a, kw = getTol(rtol=c)
+        r, a = getTol(rtol=c)
         self.assertEqual(a, d)
         self.assertEqual(r, c)
-        self.assertEqual(kw, {})
-        r, a, kw = getTol(rtol=c, check=True)
-        self.assertEqual(kw, {"check": True})
-        r, a, kw = getTol(tol=c)
+        r, a = getTol(tol=c)
         self.assertEqual(a, c)
         self.assertEqual(r, c)
-        self.assertEqual(kw, {})
-        r, a, kw = getTol(tol=c, check=True)
-        self.assertEqual(kw, {"check": True})
 
     def test_train_then_test_root(self):
         """

--- a/tests/test_BaseRegTest.py
+++ b/tests/test_BaseRegTest.py
@@ -23,9 +23,7 @@ par_vals = {
 }
 
 
-class TestBaseRegTest(unittest.TestCase):
-    N_PROCS = 2
-
+class TestGetTol(unittest.TestCase):
     def test_tol(self):
         """
         Test that the getTol function is returning the appropriate values
@@ -46,6 +44,10 @@ class TestBaseRegTest(unittest.TestCase):
         r, a = getTol(tol=c)
         self.assertEqual(a, c)
         self.assertEqual(r, c)
+
+
+class TestBaseRegTest(unittest.TestCase):
+    N_PROCS = 2
 
     def regression_test_root(self, handler):
         """
@@ -110,3 +112,7 @@ class TestBaseRegTest(unittest.TestCase):
         self.assertEqual(test_vals, par_vals)
         with BaseRegTest(self.ref_file, train=False) as handler:
             self.regression_test_par(handler)
+
+    def tearDown(self):
+        if comm.rank == 0:
+            os.remove(self.ref_file)

--- a/tests/test_BaseRegTest.py
+++ b/tests/test_BaseRegTest.py
@@ -55,18 +55,30 @@ class TestBaseRegTest(unittest.TestCase):
         y = 1e-2
         c = 1e-3
         d = 1e-12
-        r, a = getTol(atol=x, rtol=y)
+        r, a, kw = getTol(atol=x, rtol=y)
         self.assertEqual(a, x)
         self.assertEqual(r, y)
-        r, a = getTol(atol=c)
+        self.assertEqual(kw, {})
+        r, a, kw = getTol(atol=x, rtol=y, check=True)
+        self.assertEqual(kw, {"check": True})
+        r, a, kw = getTol(atol=c)
         self.assertEqual(a, c)
         self.assertEqual(r, d)
-        r, a = getTol(rtol=c)
+        self.assertEqual(kw, {})
+        r, a, kw = getTol(atol=c, check=False)
+        self.assertEqual(kw, {"check": False})
+        r, a, kw = getTol(rtol=c)
         self.assertEqual(a, d)
         self.assertEqual(r, c)
-        r, a = getTol(tol=c)
+        self.assertEqual(kw, {})
+        r, a, kw = getTol(rtol=c, check=True)
+        self.assertEqual(kw, {"check": True})
+        r, a, kw = getTol(tol=c)
         self.assertEqual(a, c)
         self.assertEqual(r, c)
+        self.assertEqual(kw, {})
+        r, a, kw = getTol(tol=c, check=True)
+        self.assertEqual(kw, {"check": True})
 
     def test_train_then_test_root(self):
         """

--- a/tests/test_BaseRegTest.py
+++ b/tests/test_BaseRegTest.py
@@ -23,27 +23,6 @@ par_vals = {
 }
 
 
-def regression_test_root(handler):
-    """
-    This function adds values for the root proc
-    """
-    for key, val in root_vals.items():
-        if isinstance(val, dict):
-            handler.root_add_dict(key, val)
-        elif isinstance(val, (float, int)):
-            handler.root_add_val(key, val)
-
-
-def regression_test_par(handler):
-    """
-    This function adds values in parallel
-    """
-    val = comm.rank + 0.5
-    handler.par_add_val("par val", val)
-    handler.par_add_sum("par sum", val)
-    handler.par_add_norm("par norm", val)
-
-
 class TestBaseRegTest(unittest.TestCase):
     N_PROCS = 2
 
@@ -68,30 +47,66 @@ class TestBaseRegTest(unittest.TestCase):
         self.assertEqual(a, c)
         self.assertEqual(r, c)
 
+    def regression_test_root(self, handler):
+        """
+        This function adds values for the root proc
+        """
+        for key, val in root_vals.items():
+            if isinstance(val, dict):
+                handler.root_add_dict(key, val)
+            elif isinstance(val, (float, int)):
+                handler.root_add_val(key, val)
+
+        if handler.train:
+            # check non-unique training value will throw ValueError
+            # due to context manager, need to check for the generic Exception rather than specific ValueError
+            with self.assertRaises(Exception):
+                handler.root_add_val("scalar", 2.0)
+            with self.assertRaises(Exception):
+                handler.root_add_val("simple dictionary", {"c": -1})
+        else:
+            with self.assertRaises(Exception):
+                handler.root_add_val("nonexisting dictionary", {"c": -1})
+
+        # check if the compare argument works in training mode
+        handler.root_add_val("scalar", 1.0, compare=True)
+        with self.assertRaises(Exception):
+            handler.root_add_val("scalar", 2.0, compare=True)
+
+    def regression_test_par(self, handler):
+        """
+        This function adds values in parallel
+        """
+        val = comm.rank + 0.5
+        handler.par_add_val("par val", val)
+        handler.par_add_sum("par sum", val)
+        handler.par_add_norm("par norm", val)
+
     def test_train_then_test_root(self):
         """
         Test for adding values to the root, both in training and in testing
         Also tests read/write in the process
         """
-        fileName = os.path.join(baseDir, "test_root.ref")
-        handler = BaseRegTest(fileName, train=True)
-        regression_test_root(handler)
-        handler.writeRef()
+        self.ref_file = os.path.join(baseDir, "test_root.ref")
+        with BaseRegTest(self.ref_file, train=True) as handler:
+            self.regression_test_root(handler)
         test_vals = handler.readRef()
+        # check the two values match
         self.assertEqual(test_vals, root_vals)
-        handler = BaseRegTest(fileName, train=False)
-        regression_test_root(handler)
+
+        # test train=False
+        handler = BaseRegTest(self.ref_file, train=False)
+        self.regression_test_root(handler)
 
     def test_train_then_test_par(self):
         """
         Test for adding values in parallel, both in training and in testing
         Also tests read/write in the process
         """
-        fileName = os.path.join(baseDir, "test_par.ref")
-        handler = BaseRegTest(fileName, train=True)
-        regression_test_par(handler)
-        handler.writeRef()
+        self.ref_file = os.path.join(baseDir, "test_par.ref")
+        with BaseRegTest(self.ref_file, train=True) as handler:
+            self.regression_test_par(handler)
         test_vals = handler.readRef()
         self.assertEqual(test_vals, par_vals)
-        handler = BaseRegTest(fileName, train=False)
-        regression_test_par(handler)
+        with BaseRegTest(self.ref_file, train=False) as handler:
+            self.regression_test_par(handler)


### PR DESCRIPTION
## Purpose
This PR added a new keyword option `compare` when using the various add functions except for the `add_dict` function. If not in training mode, setting `compare=True` will compare an existing value with what's being added, instead of adding a new value. This is useful when the tests generate two values that should match. Instead of adding both to the reference file, we can now add just one, and use the `check=True` option to check the other value against it.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
I added a few new tests.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
