### PR TITLE
Added Deprecated Options

### DIFF
--- a/baseclasses/BaseSolver.py
+++ b/baseclasses/BaseSolver.py
@@ -74,7 +74,7 @@ class BaseSolver(object):
         # Make sure we are not trying to change an immutable option if
         # we are not allowed to.
         if self.solverCreated and name in self.imOptions:
-            raise Error("Option '%-35s' cannot be modified after the solver " "is created." % name)
+            raise Error(f"Option {name} cannot be modified after the solver is created.")
 
         # If the default provides a list of acceptable values, check whether the value is valid
         if isinstance(defaultValue, list) and defaultType is not list:
@@ -115,16 +115,16 @@ class BaseSolver(object):
         if name in self.defaultOptions:
             return self.options[name]
         else:
-            raise Error("%s is not a valid option name." % name)
+            raise Error(f"{name} is not a valid option name.")
 
     def printCurrentOptions(self):
         """
         Prints a nicely formatted dictionary of all the current solver
         options to the stdout on the root processor"""
         if self.comm.rank == 0:
-            print("+---------------------------------------+")
-            print("|          All %s Options:          |" % self.name)
-            print("+---------------------------------------+")
+            print("+----------------------------------------+")
+            print("|" + f"All {self.name} Options:".center(40) + "|")
+            print("+----------------------------------------+")
             # Need to assemble a temporary dictionary
             tmpDict = {}
             for key in self.options:
@@ -137,9 +137,9 @@ class BaseSolver(object):
         options that have been modified from the defaults to the root
         processor"""
         if self.comm.rank == 0:
-            print("+---------------------------------------+")
-            print("|      All Modified %s Options:     |" % self.name)
-            print("+---------------------------------------+")
+            print("+----------------------------------------+")
+            print("|" + f"All Modified {self.name} Options:".center(40) + "|")
+            print("+----------------------------------------+")
             # Need to assemble a temporary dictionary
             tmpDict = {}
             for key in self.options:

--- a/baseclasses/BaseSolver.py
+++ b/baseclasses/BaseSolver.py
@@ -4,7 +4,7 @@ BaseSolver
 Holds a basic Python Analysis Classes (base and inherited).
 """
 from pprint import pprint as pp
-from .utils import CaseInsensitiveDict, Error
+from .utils import CaseInsensitiveDict, CaseInsensitiveSet, Error
 
 # =============================================================================
 # BaseSolver Class
@@ -14,7 +14,7 @@ class BaseSolver(object):
     Abstract Class for a basic Solver Object
     """
 
-    def __init__(self, name, category={}, def_options={}, options={}):
+    def __init__(self, name, category={}, def_options={}, options={}, imOptions=set(), depOptions={}):
         """
         Solver Class Initialization
         """
@@ -23,8 +23,9 @@ class BaseSolver(object):
         self.category = category
         self.options = CaseInsensitiveDict()
         self.defaultOptions = CaseInsensitiveDict(def_options)
+        self.imOptions = CaseInsensitiveSet(imOptions)
+        self.deprecatedOptions = CaseInsensitiveDict(depOptions)
         self.solverCreated = False
-        self.imOptions = CaseInsensitiveDict()
 
         # Initialize Options
         for key, (optionType, optionValue) in self.defaultOptions.items():
@@ -65,7 +66,10 @@ class BaseSolver(object):
         try:
             defaultType, defaultValue = self.defaultOptions[name]
         except KeyError:
-            Error("Option '%-30s' is not a valid %s option." % (name, self.name))
+            raise Error(f"Option {name} is not a valid {self.name} option.")
+
+        if name in self.deprecatedOptions:
+            raise Error(f"Option {name} is deprecated. {self.deprecatedOptions[name]}")
 
         # Make sure we are not trying to change an immutable option if
         # we are not allowed to.

--- a/baseclasses/BaseSolver.py
+++ b/baseclasses/BaseSolver.py
@@ -14,7 +14,7 @@ class BaseSolver(object):
     Abstract Class for a basic Solver Object
     """
 
-    def __init__(self, name, category={}, def_options={}, options={}, imOptions=set(), depOptions={}):
+    def __init__(self, name, category={}, def_options={}, options={}, immutableOptions=set(), deprecatedOptions={}):
         """
         Solver Class Initialization
         """
@@ -23,8 +23,8 @@ class BaseSolver(object):
         self.category = category
         self.options = CaseInsensitiveDict()
         self.defaultOptions = CaseInsensitiveDict(def_options)
-        self.imOptions = CaseInsensitiveSet(imOptions)
-        self.deprecatedOptions = CaseInsensitiveDict(depOptions)
+        self.immutableOptions = CaseInsensitiveSet(immutableOptions)
+        self.deprecatedOptions = CaseInsensitiveDict(deprecatedOptions)
         self.solverCreated = False
 
         # Initialize Options
@@ -73,7 +73,7 @@ class BaseSolver(object):
 
         # Make sure we are not trying to change an immutable option if
         # we are not allowed to.
-        if self.solverCreated and name in self.imOptions:
+        if self.solverCreated and name in self.immutableOptions:
             raise Error(f"Option {name} cannot be modified after the solver is created.")
 
         # If the default provides a list of acceptable values, check whether the value is valid

--- a/baseclasses/BaseSolver.py
+++ b/baseclasses/BaseSolver.py
@@ -66,10 +66,10 @@ class BaseSolver(object):
         try:
             defaultType, defaultValue = self.defaultOptions[name]
         except KeyError:
-            raise Error(f"Option {name} is not a valid {self.name} option.")
-
-        if name in self.deprecatedOptions:
-            raise Error(f"Option {name} is deprecated. {self.deprecatedOptions[name]}")
+            if name in self.deprecatedOptions:
+                raise Error(f"Option {name} is deprecated. {self.deprecatedOptions[name]}")
+            else:
+                raise Error(f"Option {name} is not a valid {self.name} option.")
 
         # Make sure we are not trying to change an immutable option if
         # we are not allowed to.

--- a/baseclasses/__init__.py
+++ b/baseclasses/__init__.py
@@ -25,4 +25,3 @@ from .pyLG_problem import LGProblem
 
 from .py3Util import getPy3SafeString
 from .BaseRegTest import BaseRegTest
-from .utils import CaseInsensitiveDict, CaseInsensitiveSet, Error

--- a/baseclasses/__init__.py
+++ b/baseclasses/__init__.py
@@ -25,4 +25,4 @@ from .pyLG_problem import LGProblem
 
 from .py3Util import getPy3SafeString
 from .BaseRegTest import BaseRegTest
-from .utils import CaseInsensitiveDict, Error
+from .utils import CaseInsensitiveDict, CaseInsensitiveSet, Error

--- a/baseclasses/pyAero_problem.py
+++ b/baseclasses/pyAero_problem.py
@@ -264,7 +264,7 @@ areaRef=0.772893541, chordRef=0.64607, xRef=0.0, zRef=0.0, alpha=3.06, T=255.56)
         if "evalFuncs" in kwargs:
             self.evalFuncs = set(kwargs["evalFuncs"])
         if "funcs" in kwargs:
-            warnings.warn("funcs should **not** be an argument. Use 'evalFuncs'" "instead.")
+            warnings.warn("funcs should **not** be an argument. Use 'evalFuncs' instead.")
             self.evalFuncs = set(kwargs["funcs"])
 
         # we cast the set to a sorted list, so that each proc can loop over in the same order

--- a/baseclasses/pyAero_solver.py
+++ b/baseclasses/pyAero_solver.py
@@ -26,13 +26,13 @@ class AeroSolver(BaseSolver):
     Abstract Class for Aerodynamic Solver Object
     """
 
-    def __init__(self, name, category={}, def_options={}, informs={}, options={}):
+    def __init__(self, name, *args, **kwargs):
 
         """
         AeroSolver Class Initialization
         """
         # Setup option info
-        super().__init__(name, category=category, def_options=def_options, options=options)
+        super().__init__(name, *args, **kwargs)
         self.families = CaseInsensitiveDict()
         self._updateGeomInfo = False
 

--- a/baseclasses/pyAero_solver.py
+++ b/baseclasses/pyAero_solver.py
@@ -26,13 +26,22 @@ class AeroSolver(BaseSolver):
     Abstract Class for Aerodynamic Solver Object
     """
 
-    def __init__(self, name, *args, **kwargs):
+    def __init__(
+        self, name, category={}, def_options={}, informs={}, options={}, immutableOptions=set(), deprecatedOptions={}
+    ):
 
         """
         AeroSolver Class Initialization
         """
         # Setup option info
-        super().__init__(name, *args, **kwargs)
+        super().__init__(
+            name,
+            category=category,
+            def_options=def_options,
+            options=options,
+            immutableOptions=immutableOptions,
+            deprecatedOptions=deprecatedOptions,
+        )
         self.families = CaseInsensitiveDict()
         self._updateGeomInfo = False
 
@@ -270,7 +279,7 @@ class AeroSolver(BaseSolver):
         # Do some error checking
         if groupName in self.families:
             raise Error(
-                "The specified groupName '%s' already exists in the cgns file or has already been added." % groupName
+                "The specified groupName '%s' already exists in the " "cgns file or has already been added." % groupName
             )
 
         # We can actually allow for nested groups. That is, an entry
@@ -342,7 +351,7 @@ class AeroSolver(BaseSolver):
 
         self._updateGeomInfo = True
         if self.mesh is None:
-            raise Error("Cannot set new surface coordinate locations without a mesh warping object present.")
+            raise Error("Cannot set new surface coordinate locations without a mesh" "warping object present.")
 
         # First get the surface coordinates of the meshFamily in case
         # the groupName is a subset, those values will remain unchanged.

--- a/baseclasses/pyAero_solver.py
+++ b/baseclasses/pyAero_solver.py
@@ -162,7 +162,7 @@ class AeroSolver(BaseSolver):
         if self.comm.rank == 0:
             f = open(fileName, "w")
             f.write('TITLE = "%s Surface Mesh"\n' % self.name)
-            f.write('VARIABLES = "CoordinateX CoordinateY CoordinateZ"\n')
+            f.write('VARIABLES = "CoordinateX" "CoordinateY" "CoordinateZ"\n')
             f.write("Zone T=%s\n" % ("surf"))
             f.write("Nodes = %d, Elements = %d ZONETYPE=FETRIANGLE\n" % (len(p0) * 3, len(p0)))
             f.write("DATAPACKING=POINT\n")

--- a/baseclasses/pyAero_solver.py
+++ b/baseclasses/pyAero_solver.py
@@ -162,7 +162,7 @@ class AeroSolver(BaseSolver):
         if self.comm.rank == 0:
             f = open(fileName, "w")
             f.write('TITLE = "%s Surface Mesh"\n' % self.name)
-            f.write('VARIABLES = "CoordinateX" "CoordinateY" "CoordinateZ"\n')
+            f.write('VARIABLES = "CoordinateX CoordinateY CoordinateZ"\n')
             f.write("Zone T=%s\n" % ("surf"))
             f.write("Nodes = %d, Elements = %d ZONETYPE=FETRIANGLE\n" % (len(p0) * 3, len(p0)))
             f.write("DATAPACKING=POINT\n")
@@ -270,7 +270,7 @@ class AeroSolver(BaseSolver):
         # Do some error checking
         if groupName in self.families:
             raise Error(
-                "The specified groupName '%s' already exists in the " "cgns file or has already been added." % groupName
+                "The specified groupName '%s' already exists in the cgns file or has already been added." % groupName
             )
 
         # We can actually allow for nested groups. That is, an entry
@@ -342,7 +342,7 @@ class AeroSolver(BaseSolver):
 
         self._updateGeomInfo = True
         if self.mesh is None:
-            raise Error("Cannot set new surface coordinate locations without a mesh" "warping object present.")
+            raise Error("Cannot set new surface coordinate locations without a mesh warping object present.")
 
         # First get the surface coordinates of the meshFamily in case
         # the groupName is a subset, those values will remain unchanged.

--- a/baseclasses/pyFieldPerformance_problem.py
+++ b/baseclasses/pyFieldPerformance_problem.py
@@ -167,7 +167,7 @@ class FieldPerformanceProblem(object):
         if "evalFuncs" in kwargs:
             self.evalFuncs = set(kwargs["evalFuncs"])
         if "funcs" in kwargs:
-            warnings.warn("funcs should **not** be an argument. Use 'evalFuncs'" "instead.")
+            warnings.warn("funcs should **not** be an argument. Use 'evalFuncs' instead.")
             self.evalFuncs = set(kwargs["funcs"])
 
         # Specify the set of possible design variables:

--- a/baseclasses/pyStruct_problem.py
+++ b/baseclasses/pyStruct_problem.py
@@ -50,7 +50,7 @@ class StructProblem(object):
         if "evalFuncs" in kwargs:
             self.evalFuncs = set(kwargs["evalFuncs"])
         if "funcs" in kwargs:
-            warnings.warn("funcs should **not** be an argument. Use 'evalFuncs'" "instead.")
+            warnings.warn("funcs should **not** be an argument. Use 'evalFuncs' instead.")
             if self.evalFuncs is None:
                 self.evalFuncs = set(kwargs["funcs"])
 

--- a/baseclasses/pyWeight_problem.py
+++ b/baseclasses/pyWeight_problem.py
@@ -193,7 +193,7 @@ class WeightProblem(object):
         """
         f = open(fileName, "w")
         f.write('TITLE = "weight_problem Surface Mesh"\n')
-        f.write('VARIABLES = "CoordinateX" "CoordinateY" "CoordinateZ"\n')
+        f.write('VARIABLES = "CoordinateX CoordinateY CoordinateZ"\n')
         f.write("Zone T=%s\n" % ("surf"))
         f.write("Nodes = %d, Elements = %d ZONETYPE=FETRIANGLE\n" % (len(self.p0) * 3, len(self.p0)))
         f.write("DATAPACKING=POINT\n")
@@ -225,7 +225,7 @@ class WeightProblem(object):
 
         f = open(fileName, "w")
         f.write('TITLE = "Weight_problem Data"\n')
-        f.write('VARIABLES = "CoordinateX" "CoordinateY" "CoordinateZ"\n')
+        f.write('VARIABLES = "CoordinateX CoordinateY CoordinateZ"\n')
 
         for compKey in self.components.keys():
             comp = self.components[compKey]

--- a/baseclasses/pyWeight_problem.py
+++ b/baseclasses/pyWeight_problem.py
@@ -193,7 +193,7 @@ class WeightProblem(object):
         """
         f = open(fileName, "w")
         f.write('TITLE = "weight_problem Surface Mesh"\n')
-        f.write('VARIABLES = "CoordinateX CoordinateY CoordinateZ"\n')
+        f.write('VARIABLES = "CoordinateX" "CoordinateY" "CoordinateZ"\n')
         f.write("Zone T=%s\n" % ("surf"))
         f.write("Nodes = %d, Elements = %d ZONETYPE=FETRIANGLE\n" % (len(self.p0) * 3, len(self.p0)))
         f.write("DATAPACKING=POINT\n")
@@ -225,7 +225,7 @@ class WeightProblem(object):
 
         f = open(fileName, "w")
         f.write('TITLE = "Weight_problem Data"\n')
-        f.write('VARIABLES = "CoordinateX CoordinateY CoordinateZ"\n')
+        f.write('VARIABLES = "CoordinateX" "CoordinateY" "CoordinateZ"\n')
 
         for compKey in self.components.keys():
             comp = self.components[compKey]

--- a/baseclasses/utils.py
+++ b/baseclasses/utils.py
@@ -1,4 +1,11 @@
 class CaseInsensitiveDict(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # convert keys to lower case
+        for k in list(self.keys()):
+            v = super().pop(k)
+            self.__setitem__(k, v)
+
     def __setitem__(self, key, value):
         super().__setitem__(key.lower(), value)
 
@@ -7,6 +14,30 @@ class CaseInsensitiveDict(dict):
 
     def __contains__(self, key):
         return super().__contains__(key.lower())
+
+    def __delitem__(self, key):
+        super().__delitem__(key.lower())
+
+    def pop(self, key, *args, **kwargs):
+        super().pop(key.lower(), *args, **kwargs)
+
+    def get(self, key, *args, **kwargs):
+        return super().get(key.lower(), *args, **kwargs)
+
+
+class CaseInsensitiveSet(set):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # convert entries to lowe case
+        for k in self:
+            super().remove(k)
+            self.add(k)
+
+    def add(self, item):
+        super().add(item.lower())
+
+    def __contains__(self, item):
+        return super().__contains__(item.lower())
 
 
 class Error(Exception):

--- a/baseclasses/utils.py
+++ b/baseclasses/utils.py
@@ -1,4 +1,12 @@
 class CaseInsensitiveDict(dict):
+    """
+    Python dictionary where the keys are case-insensitive.
+    Note that this assumes the keys are strings, and indeed will fail if you try to
+    create an instance where keys are not strings.
+    All common Python dictionary operations are supported, and additional operations
+    can be added easily.
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # convert keys to lower case
@@ -26,6 +34,14 @@ class CaseInsensitiveDict(dict):
 
 
 class CaseInsensitiveSet(set):
+    """
+    Python set where the elements are case-insensitive.
+    Note that this assumes the elements are strings, and indeed will fail if you try to
+    create an instance where elements are not strings.
+    All common Python set operations are supported, and additional operations
+    can be added easily.
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # convert entries to lowe case

--- a/tests/test_BaseSolver.py
+++ b/tests/test_BaseSolver.py
@@ -1,5 +1,6 @@
 import unittest
-from baseclasses import BaseSolver, Error
+from baseclasses import BaseSolver
+from baseclasses.utils import Error
 
 
 class SOLVER(BaseSolver):

--- a/tests/test_BaseSolver.py
+++ b/tests/test_BaseSolver.py
@@ -16,9 +16,13 @@ class SOLVER(BaseSolver):
             "stroption": [str, ["str1", "str2", "str3"]],
             "listoption": [list, []],
         }
+        imOptions = {"strOption"}
+        depOptions = {
+            "oldOption": "Use boolOption instead.",
+        }
 
         # Initialize the inherited BaseSolver
-        super().__init__(name, category, def_opts, options)
+        super().__init__(name, category, def_opts, options, imOptions=imOptions, depOptions=depOptions)
 
 
 class TestOptions(unittest.TestCase):
@@ -29,7 +33,6 @@ class TestOptions(unittest.TestCase):
         intValue_set = 3
         options = {"floatOption": floatValue_set, "intOption": intValue_set}
         solver = SOLVER("test", options=options)
-        solver.imOptions = {"strOption"}
 
         # test getOption for initialized option
         floatValue_get = solver.getOption("floatOption")
@@ -67,4 +70,6 @@ class TestOptions(unittest.TestCase):
         with self.assertRaises(Error):
             solver.setOption("floatOption", 4)  # test type checking without list
         with self.assertRaises(Error):
-            solver.setOption("strOption", "str2")  # test imOptions
+            solver.setOption("strOPTION", "str2")  # test imOptions
+        with self.assertRaises(Error):
+            solver.setOption("oldoption", 4)  # test depOptions

--- a/tests/test_BaseSolver.py
+++ b/tests/test_BaseSolver.py
@@ -16,13 +16,15 @@ class SOLVER(BaseSolver):
             "stroption": [str, ["str1", "str2", "str3"]],
             "listoption": [list, []],
         }
-        imOptions = {"strOption"}
-        depOptions = {
+        immutableOptions = {"strOption"}
+        deprecatedOptions = {
             "oldOption": "Use boolOption instead.",
         }
 
         # Initialize the inherited BaseSolver
-        super().__init__(name, category, def_opts, options, imOptions=imOptions, depOptions=depOptions)
+        super().__init__(
+            name, category, def_opts, options, immutableOptions=immutableOptions, deprecatedOptions=deprecatedOptions
+        )
 
 
 class TestOptions(unittest.TestCase):
@@ -70,6 +72,6 @@ class TestOptions(unittest.TestCase):
         with self.assertRaises(Error):
             solver.setOption("floatOption", 4)  # test type checking without list
         with self.assertRaises(Error):
-            solver.setOption("strOPTION", "str2")  # test imOptions
+            solver.setOption("strOPTION", "str2")  # test  immutableOptions
         with self.assertRaises(Error):
-            solver.setOption("oldoption", 4)  # test depOptions
+            solver.setOption("oldoption", 4)  # test deprecatedOptions

--- a/tests/test_CaseInsensitve.py
+++ b/tests/test_CaseInsensitve.py
@@ -1,5 +1,5 @@
 import unittest
-from baseclasses import CaseInsensitiveDict, CaseInsensitiveSet
+from baseclasses.utils import CaseInsensitiveDict, CaseInsensitiveSet
 
 
 class TestCaseInsensitiveClasses(unittest.TestCase):

--- a/tests/test_CaseInsensitve.py
+++ b/tests/test_CaseInsensitve.py
@@ -1,0 +1,37 @@
+import unittest
+from baseclasses import CaseInsensitiveDict, CaseInsensitiveSet
+
+
+class TestCaseInsensitiveClasses(unittest.TestCase):
+    def test_dict(self):
+        value1 = 123
+        value2 = 321
+        value3 = 132
+        d = CaseInsensitiveDict({"OPtion1": value1})
+        self.assertEqual(d["OPTION1"], value1)
+        d["OPTION1"] = value2
+        self.assertEqual(d["option1"], value2)
+        self.assertIn("Option1", d)
+        d["option2"] = value1
+        self.assertEqual(len(d), 2)
+        self.assertIn("OPTION2", d)
+        d.pop("Option2")
+        self.assertEqual(len(d), 1)
+        self.assertEqual(d.get("opTION1"), value2)
+        self.assertEqual(list(d), ["option1"])
+        d2 = CaseInsensitiveDict({"OPTION3": value3})
+        d.update(d2)
+        self.assertIn("option3", d)
+        self.assertEqual(d["Option3"], value3)
+
+    def test_set(self):
+        s = CaseInsensitiveSet({"Option1"})
+        self.assertIn("OPTION1", s)
+        s.add("OPTION2")
+        self.assertIn("option2", s)
+        s2 = CaseInsensitiveSet({"OPTION2", "opTION3"})
+        s.update(s2)
+        self.assertEqual(len(s), 3)
+        s.remove("option3")
+        self.assertNotIn("OPTION3", s)
+        self.assertEqual(len(s), 2)

--- a/tests/test_CaseInsensitve.py
+++ b/tests/test_CaseInsensitve.py
@@ -8,30 +8,44 @@ class TestCaseInsensitiveClasses(unittest.TestCase):
         value2 = 321
         value3 = 132
         d = CaseInsensitiveDict({"OPtion1": value1})
+        # test __getitem__
         self.assertEqual(d["OPTION1"], value1)
+        # test __setitem__
         d["OPTION1"] = value2
         self.assertEqual(d["option1"], value2)
+        # test __contains__
         self.assertIn("Option1", d)
         d["option2"] = value1
         self.assertEqual(len(d), 2)
         self.assertIn("OPTION2", d)
+        # test pop()
         d.pop("Option2")
         self.assertEqual(len(d), 1)
         self.assertEqual(d.get("opTION1"), value2)
         self.assertEqual(list(d), ["option1"])
         d2 = CaseInsensitiveDict({"OPTION3": value3})
+        # test update()
         d.update(d2)
         self.assertIn("option3", d)
         self.assertEqual(d["Option3"], value3)
 
     def test_set(self):
+        # test __contains__ and add()
         s = CaseInsensitiveSet({"Option1"})
         self.assertIn("OPTION1", s)
         s.add("OPTION2")
         self.assertIn("option2", s)
+        # test update()
         s2 = CaseInsensitiveSet({"OPTION2", "opTION3"})
         s.update(s2)
         self.assertEqual(len(s), 3)
+        # test set operations
+        self.assertTrue(s2.issubset(s))
+        self.assertFalse({"Option2"}.issubset(s))  # set is case sensitive so this should fail
+        self.assertTrue(CaseInsensitiveSet({"Option2"}).issubset(s))  # and this should pass
+        # test remove
         s.remove("option3")
         self.assertNotIn("OPTION3", s)
         self.assertEqual(len(s), 2)
+        s3 = s.union(s2)
+        self.assertEqual(s3, CaseInsensitiveSet({"option1", "option2", "option3"}))


### PR DESCRIPTION
## Purpose
This PR does the following:
- Added `CaseInsensitiveSet` and updated `CaseInsensitiveDict`
- Added tests for those
- Switched immutable options to use `CaseInsensitiveSet`
- Added support for deprecated options
- Both immutable and deprecated options can be passed in when the class is created. I have also added some tests for this
- Minor string/formatting fixes

Nothing in this PR should break backwards compatibility.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
I have added a few tests

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
