### PR TITLE
Added multitype BaseSolver test

### DIFF
--- a/tests/test_BaseSolver.py
+++ b/tests/test_BaseSolver.py
@@ -8,14 +8,14 @@ class SOLVER(BaseSolver):
 
         """Create an artificial class for testing"""
 
-        name = name
         category = "Solver for testing BaseSolver"
         def_opts = {
-            "booloption": [bool, True],
-            "floatoption": [float, 10.0],
-            "intoption": [int, [1, 2, 3]],
-            "stroption": [str, ["str1", "str2", "str3"]],
-            "listoption": [list, []],
+            "boolOption": [bool, True],
+            "floatOption": [float, 10.0],
+            "intOption": [int, [1, 2, 3]],
+            "strOption": [str, ["str1", "str2", "str3"]],
+            "listOption": [list, []],
+            "multiOption": [(str, dict), {}],
         }
         immutableOptions = {"strOption"}
         deprecatedOptions = {
@@ -62,6 +62,13 @@ class TestOptions(unittest.TestCase):
         solver.setOption("listOption", listValue_set)
         listValue_get = solver.getOption("listOption")
         self.assertEqual(listValue_set, listValue_get)
+
+        # test options that accept multiple types
+        testValues = ["value", {"key": "value"}]
+        for multiValue_set in testValues:
+            solver.setOption("multiOption", multiValue_set)
+            multiValue_get = solver.getOption("multiOption")
+            self.assertEqual(multiValue_set, multiValue_get)
 
         # test Errors
         with self.assertRaises(Error):


### PR DESCRIPTION
## Purpose
BaseSolver can handle options that accept multiple types if a tuple of types is provided in the default options. This is one way to address the second point in #26. I added a test to show that this works.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
