### PR TITLE
Added root print function

### DIFF
--- a/tests/test_BaseSolver.py
+++ b/tests/test_BaseSolver.py
@@ -36,6 +36,7 @@ class TestOptions(unittest.TestCase):
         intValue_set = 3
         options = {"floatOption": floatValue_set, "intOption": intValue_set}
         solver = SOLVER("test", options=options)
+        solver.printCurrentOptions()
 
         # test getOption for initialized option
         floatValue_get = solver.getOption("floatOption")
@@ -62,6 +63,7 @@ class TestOptions(unittest.TestCase):
         solver.setOption("listOption", listValue_set)
         listValue_get = solver.getOption("listOption")
         self.assertEqual(listValue_set, listValue_get)
+        solver.printModifiedOptions()
 
         # test Errors
         with self.assertRaises(Error):


### PR DESCRIPTION
## Purpose
I added a function `BaseSolver.pp()` which will print on the root proc if `self.comm` is defined. I also updated the printing functions `printCurrentOptions()` and `printModifiedOptions()` to use this function. Also added tests for these.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
I added tests for the two functions that now use `self.pp()`.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
