### PR TITLE
Basesolver init function now accepts a comm

### DIFF
--- a/baseclasses/BaseSolver.py
+++ b/baseclasses/BaseSolver.py
@@ -14,7 +14,9 @@ class BaseSolver(object):
     Abstract Class for a basic Solver Object
     """
 
-    def __init__(self, name, category={}, def_options={}, options={}, immutableOptions=set(), deprecatedOptions={}, comm=None):
+    def __init__(
+        self, name, category={}, def_options={}, options={}, immutableOptions=set(), deprecatedOptions={}, comm=None
+    ):
         """
         Solver Class Initialization
         """

--- a/baseclasses/BaseSolver.py
+++ b/baseclasses/BaseSolver.py
@@ -14,7 +14,7 @@ class BaseSolver(object):
     Abstract Class for a basic Solver Object
     """
 
-    def __init__(self, name, category={}, def_options={}, options={}, immutableOptions=set(), deprecatedOptions={}):
+    def __init__(self, name, category={}, def_options={}, options={}, immutableOptions=set(), deprecatedOptions={}, comm=None):
         """
         Solver Class Initialization
         """
@@ -26,7 +26,7 @@ class BaseSolver(object):
         self.immutableOptions = CaseInsensitiveSet(immutableOptions)
         self.deprecatedOptions = CaseInsensitiveDict(deprecatedOptions)
         self.solverCreated = False
-        self.comm = None
+        self.comm = comm
 
         # Initialize Options
         for key, (optionType, optionValue) in self.defaultOptions.items():
@@ -146,7 +146,7 @@ class BaseSolver(object):
         tmpDict = {}
         for key in self.options:
             defaultType, defaultValue = self.defaultOptions[key]
-            if defaultType == list and not isinstance(defaultValue, list):
+            if defaultType is list and not isinstance(defaultValue, list):
                 defaultValue = defaultValue[0]
             optionValue = self.getOption(key)
             if optionValue != defaultValue:
@@ -156,7 +156,7 @@ class BaseSolver(object):
     def pp(self, obj):
         """
         This method prints ``obj`` (via pprint) on the root proc of ``self.comm`` if it exists.
-        Otherswise it will just print ``obj``.
+        Otherwise it will just print ``obj``.
 
         Parameters
         ----------

--- a/baseclasses/BaseSolver.py
+++ b/baseclasses/BaseSolver.py
@@ -15,7 +15,7 @@ class BaseSolver(object):
     """
 
     def __init__(
-        self, name, category={}, def_options={}, options={}, immutableOptions=set(), deprecatedOptions={}, comm=None
+        self, name, category, defaultOptions={}, options={}, immutableOptions=set(), deprecatedOptions={}, comm=None, informs={}
     ):
         """
         Solver Class Initialization
@@ -24,11 +24,12 @@ class BaseSolver(object):
         self.name = name
         self.category = category
         self.options = CaseInsensitiveDict()
-        self.defaultOptions = CaseInsensitiveDict(def_options)
+        self.defaultOptions = CaseInsensitiveDict(defaultOptions)
         self.immutableOptions = CaseInsensitiveSet(immutableOptions)
         self.deprecatedOptions = CaseInsensitiveDict(deprecatedOptions)
-        self.solverCreated = False
         self.comm = comm
+        self.informs = informs
+        self.solverCreated = False
 
         # Initialize Options
         for key, (optionType, optionValue) in self.defaultOptions.items():

--- a/baseclasses/__init__.py
+++ b/baseclasses/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.5"
+__version__ = "1.3.0"
 
 from .pyAero_problem import AeroProblem
 from .pyTransi_problem import TransiProblem

--- a/baseclasses/__init__.py
+++ b/baseclasses/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.4"
+__version__ = "1.2.5"
 
 from .pyAero_problem import AeroProblem
 from .pyTransi_problem import TransiProblem

--- a/baseclasses/pyAero_solver.py
+++ b/baseclasses/pyAero_solver.py
@@ -29,13 +29,13 @@ class AeroSolver(BaseSolver):
     def __init__(
         self,
         name,
-        category={},
-        def_options={},
-        informs={},
+        category,
+        defaultOptions={},
         options={},
         immutableOptions=set(),
         deprecatedOptions={},
         comm=None,
+        informs={},
     ):
 
         """
@@ -45,11 +45,12 @@ class AeroSolver(BaseSolver):
         super().__init__(
             name,
             category=category,
-            def_options=def_options,
+            defaultOptions=defaultOptions,
             options=options,
             immutableOptions=immutableOptions,
             deprecatedOptions=deprecatedOptions,
             comm=comm,
+            informs=informs,
         )
         self.families = CaseInsensitiveDict()
         self._updateGeomInfo = False

--- a/baseclasses/pyAero_solver.py
+++ b/baseclasses/pyAero_solver.py
@@ -27,7 +27,15 @@ class AeroSolver(BaseSolver):
     """
 
     def __init__(
-        self, name, category={}, def_options={}, informs={}, options={}, immutableOptions=set(), deprecatedOptions={}
+        self,
+        name,
+        category={},
+        def_options={},
+        informs={},
+        options={},
+        immutableOptions=set(),
+        deprecatedOptions={},
+        comm=None,
     ):
 
         """
@@ -41,6 +49,7 @@ class AeroSolver(BaseSolver):
             options=options,
             immutableOptions=immutableOptions,
             deprecatedOptions=deprecatedOptions,
+            comm=comm,
         )
         self.families = CaseInsensitiveDict()
         self._updateGeomInfo = False

--- a/tests/test_BaseSolver.py
+++ b/tests/test_BaseSolver.py
@@ -9,7 +9,7 @@ from baseclasses.utils import Error
 
 
 class SOLVER(BaseSolver):
-    def __init__(self, name, options={}, comm=None, *args, **kwargs):
+    def __init__(self, name, options={}, comm=None):
 
         """Create an artificial class for testing"""
 

--- a/tests/test_BaseSolver.py
+++ b/tests/test_BaseSolver.py
@@ -1,4 +1,3 @@
-
 try:
     from mpi4py import MPI
 except ImportError:
@@ -28,15 +27,22 @@ class SOLVER(BaseSolver):
             "oldOption": "Use boolOption instead.",
         }
 
+        informs = {
+            -1: "Failure -1",
+            0: "Success",
+            1: "Failure 1",
+        }
+
         # Initialize the inherited BaseSolver
         super().__init__(
             name,
             category,
-            defaultOptions,
+            defaultOptions=defaultOptions,
             options=options,
             immutableOptions=immutableOptions,
             deprecatedOptions=deprecatedOptions,
             comm=comm,
+            informs=informs,
         )
 
 
@@ -98,6 +104,7 @@ class TestOptions(unittest.TestCase):
         with self.assertRaises(Error):
             solver.setOption("oldoption", 4)  # test deprecatedOptions
 
+
 class TestComm(unittest.TestCase):
 
     N_PROCS = 2
@@ -114,3 +121,9 @@ class TestComm(unittest.TestCase):
         solver = SOLVER("testComm", comm=None)
         self.assertTrue(solver.comm is None)
         solver.printCurrentOptions()
+
+
+class TestInforms(unittest.TestCase):
+    def test_informs(self):
+        solver = SOLVER("testInforms")
+        self.assertEqual(solver.informs[0], "Success")

--- a/tests/test_BaseSolver.py
+++ b/tests/test_BaseSolver.py
@@ -1,15 +1,21 @@
+
+try:
+    from mpi4py import MPI
+except ImportError:
+    MPI = None
+
 import unittest
 from baseclasses import BaseSolver
 from baseclasses.utils import Error
 
 
 class SOLVER(BaseSolver):
-    def __init__(self, name, options=None, *args, **kwargs):
+    def __init__(self, name, options={}, comm=None, *args, **kwargs):
 
         """Create an artificial class for testing"""
 
         category = "Solver for testing BaseSolver"
-        def_opts = {
+        defaultOptions = {
             "boolOption": [bool, True],
             "floatOption": [float, 10.0],
             "intOption": [int, [1, 2, 3]],
@@ -24,7 +30,13 @@ class SOLVER(BaseSolver):
 
         # Initialize the inherited BaseSolver
         super().__init__(
-            name, category, def_opts, options, immutableOptions=immutableOptions, deprecatedOptions=deprecatedOptions
+            name,
+            category,
+            defaultOptions,
+            options=options,
+            immutableOptions=immutableOptions,
+            deprecatedOptions=deprecatedOptions,
+            comm=comm,
         )
 
 
@@ -85,3 +97,20 @@ class TestOptions(unittest.TestCase):
             solver.setOption("strOPTION", "str2")  # test  immutableOptions
         with self.assertRaises(Error):
             solver.setOption("oldoption", 4)  # test deprecatedOptions
+
+class TestComm(unittest.TestCase):
+
+    N_PROCS = 2
+
+    @unittest.skipIf(MPI is None, "mpi4py not imported")
+    def test_comm_with_mpi(self):
+        # initialize solver
+        solver = SOLVER("testComm", comm=MPI.COMM_WORLD)
+        self.assertFalse(solver.comm is None)
+        solver.printCurrentOptions()
+
+    def test_comm_without_mpi(self):
+        # initialize solver
+        solver = SOLVER("testComm", comm=None)
+        self.assertTrue(solver.comm is None)
+        solver.printCurrentOptions()


### PR DESCRIPTION
## Purpose
With the additions of `self.comm` in PR #29, then if the user defines `self.comm` in a child class before calling the BaseSolver `__init__` then self.comm will get overwritten with None.

This PR adds a `comm` argument in the `BaseSolver.__init__` function. This avoids having to define a `self.comm` elsewhere in child classes.
It also add a `informs` member variable (with a small test) as well as updates the argument list with a consistent camelCase variable.


## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
