### PR TITLE
Added `checkDefaultOptions`

### DIFF
--- a/baseclasses/BaseSolver.py
+++ b/baseclasses/BaseSolver.py
@@ -14,7 +14,9 @@ class BaseSolver(object):
     Abstract Class for a basic Solver Object
     """
 
-    def __init__(self, name, category={}, def_options={}, options={}, immutableOptions=set(), deprecatedOptions={}):
+    def __init__(
+        self, name, category={}, def_options={}, options={}, immutableOptions=set(), deprecatedOptions={}, informs={}
+    ):
         """
         Solver Class Initialization
         """
@@ -27,6 +29,7 @@ class BaseSolver(object):
         self.deprecatedOptions = CaseInsensitiveDict(deprecatedOptions)
         self.solverCreated = False
         self.comm = None
+        self.informs = informs
 
         # Initialize Options
         for key, (optionType, optionValue) in self.defaultOptions.items():

--- a/baseclasses/BaseSolver.py
+++ b/baseclasses/BaseSolver.py
@@ -25,7 +25,7 @@ class BaseSolver(object):
         comm=None,
         informs={},
         checkDefaultOptions=True,
-        caseInsensitive=True,
+        caseSensitiveOptions=False,
     ):
         """
         Solver Class Initialization
@@ -53,11 +53,13 @@ class BaseSolver(object):
             This is used in cases where the default options is not the complete set, which is common for external solvers.
             In such cases, no error checking is done when calling ``setOption``, but the default options are still set as options
             upon solver creation.
+        caseSensitiveOptions : bool, optional
+            A flag to specify whether the options are case sensitive or insensitive.
         """
 
         self.name = name
         self.category = category
-        if caseInsensitive:
+        if not caseSensitiveOptions:
             self.options = CaseInsensitiveDict()
             self.defaultOptions = CaseInsensitiveDict(defaultOptions)
             self.immutableOptions = CaseInsensitiveSet(immutableOptions)

--- a/baseclasses/BaseSolver.py
+++ b/baseclasses/BaseSolver.py
@@ -154,7 +154,7 @@ class BaseSolver(object):
            Return the current value of the option.
         """
 
-        if name in self.defaultOptions:
+        if name in self.defaultOptions or not self.checkDefaultOptions:
             return self.options[name]
         else:
             raise Error(f"{name} is not a valid option name.")

--- a/baseclasses/BaseSolver.py
+++ b/baseclasses/BaseSolver.py
@@ -17,7 +17,7 @@ class BaseSolver(object):
     def __init__(
         self,
         name,
-        category={},
+        category,
         defaultOptions={},
         options={},
         immutableOptions=set(),
@@ -28,6 +28,30 @@ class BaseSolver(object):
     ):
         """
         Solver Class Initialization
+
+        Parameters
+        ----------
+        name : str
+            The name of the solver
+        category : dict
+            The category of the solver
+        defaultOptions : dict, optional
+            The default options dictionary
+        options : dict, optional
+            The user-supplied options dictionary
+        immutableOptions : set of strings, optional
+            A set of immutable option names, which cannot be modified after solver creation.
+        deprecatedOptions : dict, optional
+            A dictionary containing deprecated option names, and a message to display if they were used.
+        comm : MPI Communicator, optional
+            The comm object to be used. If none, serial execution is assumed.
+        informs : dict, optional
+            A dictionary of exit code: exit message mappings.
+        checkDefaultOptions : bool, optional
+            A flag to specify whether the default options should be used for error checking.
+            This is used in cases where the default options is not the complete set, which is common for external solvers.
+            In such cases, no error checking is done when calling ``setOption``, but the default options are still set as options
+            upon solver creation.
         """
 
         self.name = name
@@ -112,6 +136,7 @@ class BaseSolver(object):
                         + f"Received data type is {type(value)}."
                     )
         else:
+            # no error checking
             self.options[name] = value
 
     def getOption(self, name):

--- a/baseclasses/BaseSolver.py
+++ b/baseclasses/BaseSolver.py
@@ -25,6 +25,7 @@ class BaseSolver(object):
         comm=None,
         informs={},
         checkDefaultOptions=True,
+        caseInsensitive=True,
     ):
         """
         Solver Class Initialization
@@ -56,10 +57,16 @@ class BaseSolver(object):
 
         self.name = name
         self.category = category
-        self.options = CaseInsensitiveDict()
-        self.defaultOptions = CaseInsensitiveDict(defaultOptions)
-        self.immutableOptions = CaseInsensitiveSet(immutableOptions)
-        self.deprecatedOptions = CaseInsensitiveDict(deprecatedOptions)
+        if caseInsensitive:
+            self.options = CaseInsensitiveDict()
+            self.defaultOptions = CaseInsensitiveDict(defaultOptions)
+            self.immutableOptions = CaseInsensitiveSet(immutableOptions)
+            self.deprecatedOptions = CaseInsensitiveDict(deprecatedOptions)
+        else:
+            self.options = {}
+            self.defaultOptions = defaultOptions
+            self.immutableOptions = immutableOptions
+            self.deprecatedOptions = deprecatedOptions
         self.comm = comm
         self.informs = informs
         self.solverCreated = False

--- a/baseclasses/BaseSolver.py
+++ b/baseclasses/BaseSolver.py
@@ -50,11 +50,11 @@ class BaseSolver(object):
             A dictionary of exit code: exit message mappings.
         checkDefaultOptions : bool, optional
             A flag to specify whether the default options should be used for error checking.
-            This is used in cases where the default options is not the complete set, which is common for external solvers.
+            This is used in cases where the default options are not the complete set, which is common for external solvers.
             In such cases, no error checking is done when calling ``setOption``, but the default options are still set as options
             upon solver creation.
         caseSensitiveOptions : bool, optional
-            A flag to specify whether the options are case sensitive or insensitive.
+            A flag to specify whether the option names are case sensitive or insensitive.
         """
 
         self.name = name
@@ -164,7 +164,13 @@ class BaseSolver(object):
         """
 
         if name in self.defaultOptions or not self.checkDefaultOptions:
-            return self.options[name]
+            if name in self.options:
+                return self.options[name]
+            else:
+                raise Error(
+                    f"Option {name} was not found. "
+                    + "Because options checking has been disabled, make sure the option has been set first."
+                )
         else:
             raise Error(f"{name} is not a valid option name.")
 

--- a/baseclasses/__init__.py
+++ b/baseclasses/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 from .pyAero_problem import AeroProblem
 from .pyTransi_problem import TransiProblem

--- a/baseclasses/pyAero_solver.py
+++ b/baseclasses/pyAero_solver.py
@@ -41,6 +41,7 @@ class AeroSolver(BaseSolver):
             options=options,
             immutableOptions=immutableOptions,
             deprecatedOptions=deprecatedOptions,
+            informs=informs,
         )
         self.families = CaseInsensitiveDict()
         self._updateGeomInfo = False

--- a/tests/test_BaseSolver.py
+++ b/tests/test_BaseSolver.py
@@ -9,7 +9,7 @@ from baseclasses.utils import Error
 
 
 class SOLVER(BaseSolver):
-    def __init__(self, name, options={}, comm=None):
+    def __init__(self, name, options={}, comm=None, checkDefaultOptions=True):
 
         """Create an artificial class for testing"""
 
@@ -43,6 +43,7 @@ class SOLVER(BaseSolver):
             deprecatedOptions=deprecatedOptions,
             comm=comm,
             informs=informs,
+            checkDefaultOptions=checkDefaultOptions,
         )
 
 
@@ -103,6 +104,12 @@ class TestOptions(unittest.TestCase):
             solver.setOption("strOPTION", "str2")  # test  immutableOptions
         with self.assertRaises(Error):
             solver.setOption("oldoption", 4)  # test deprecatedOptions
+
+    def test_checkDefaultOptions(self):
+        # initialize solver
+        solver = SOLVER("test", checkDefaultOptions=False)
+        solver.setOption("newOption", 1)
+        self.assertEqual(solver.getOption("newOption"), 1)
 
 
 class TestComm(unittest.TestCase):

--- a/tests/test_BaseSolver.py
+++ b/tests/test_BaseSolver.py
@@ -9,7 +9,7 @@ from baseclasses.utils import Error
 
 
 class SOLVER(BaseSolver):
-    def __init__(self, name, options={}, comm=None, checkDefaultOptions=True):
+    def __init__(self, name, options={}, comm=None, checkDefaultOptions=True, caseInsensitive=True):
 
         """Create an artificial class for testing"""
 
@@ -44,6 +44,7 @@ class SOLVER(BaseSolver):
             comm=comm,
             informs=informs,
             checkDefaultOptions=checkDefaultOptions,
+            caseInsensitive=caseInsensitive,
         )
 
 
@@ -110,6 +111,12 @@ class TestOptions(unittest.TestCase):
         solver = SOLVER("test", checkDefaultOptions=False)
         solver.setOption("newOption", 1)
         self.assertEqual(solver.getOption("newOption"), 1)
+
+    def test_caseSensitive(self):
+        # initialize solver
+        solver = SOLVER("test", caseInsensitive=False)
+        with self.assertRaises(Error):
+            solver.getOption("booloption")  # test that this name should be rejected
 
 
 class TestComm(unittest.TestCase):

--- a/tests/test_BaseSolver.py
+++ b/tests/test_BaseSolver.py
@@ -9,7 +9,7 @@ from baseclasses.utils import Error
 
 
 class SOLVER(BaseSolver):
-    def __init__(self, name, options={}, comm=None, checkDefaultOptions=True, caseInsensitive=True):
+    def __init__(self, name, options={}, comm=None, checkDefaultOptions=True, caseSensitiveOptions=False):
 
         """Create an artificial class for testing"""
 
@@ -44,7 +44,7 @@ class SOLVER(BaseSolver):
             comm=comm,
             informs=informs,
             checkDefaultOptions=checkDefaultOptions,
-            caseInsensitive=caseInsensitive,
+            caseSensitiveOptions=caseSensitiveOptions,
         )
 
 
@@ -114,7 +114,7 @@ class TestOptions(unittest.TestCase):
 
     def test_caseSensitive(self):
         # initialize solver
-        solver = SOLVER("test", caseInsensitive=False)
+        solver = SOLVER("test", caseSensitiveOptions=True)
         with self.assertRaises(Error):
             solver.getOption("booloption")  # test that this name should be rejected
 

--- a/tests/test_BaseSolver.py
+++ b/tests/test_BaseSolver.py
@@ -111,6 +111,8 @@ class TestOptions(unittest.TestCase):
         solver = SOLVER("test", checkDefaultOptions=False)
         solver.setOption("newOption", 1)
         self.assertEqual(solver.getOption("newOption"), 1)
+        with self.assertRaises(Error):
+            solver.getOption("nonexistant option")  # test that this name should be rejected
 
     def test_caseSensitive(self):
         # initialize solver


### PR DESCRIPTION
## Purpose
This PR adds a flag called `checkDefaultOptions`, which is used to tell BaseSolver not to do error checking against the default options when using `setOption`. This is useful when the default options are not the complete set, which could be the case when wrapping an external solver. In that case, it would be preferable to let the external solver handle its own options rather than hard-coding the options within the wrapper. The flag would tell `BaseSolver` not to perform error checking, instead letting the external solver handle that on its own.

This PR also added an option `caseSensitiveOptions`, which will force the options to be case sensitive.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
I added a new test.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
