### PR TITLE
Added a guess if option name is invalid

### DIFF
--- a/baseclasses/BaseSolver.py
+++ b/baseclasses/BaseSolver.py
@@ -3,6 +3,7 @@ BaseSolver
 
 Holds a basic Python Analysis Classes (base and inherited).
 """
+from difflib import get_close_matches
 from pprint import pprint
 from .utils import CaseInsensitiveDict, CaseInsensitiveSet, Error
 
@@ -116,7 +117,8 @@ class BaseSolver(object):
                 if name in self.deprecatedOptions:
                     raise Error(f"Option {name} is deprecated. {self.deprecatedOptions[name]}")
                 else:
-                    raise Error(f"Option {name} is not a valid {self.name} option.")
+                    guess = get_close_matches(name, list(self.defaultOptions.keys()), n=1, cutoff=0.0)[0]
+                    raise Error(f"Option {name} is not a valid {self.name} option. Perhaps you meant {guess}?")
 
         # Make sure we are not trying to change an immutable option if
         # we are not allowed to.
@@ -172,7 +174,8 @@ class BaseSolver(object):
                     + "Because options checking has been disabled, make sure the option has been set first."
                 )
         else:
-            raise Error(f"{name} is not a valid option name.")
+            guess = get_close_matches(name, list(self.defaultOptions.keys()), n=1, cutoff=0.0)[0]
+            raise Error(f"{name} is not a valid option name. Perhaps you meant {guess}?")
 
     def printCurrentOptions(self):
         """

--- a/tests/test_BaseSolver.py
+++ b/tests/test_BaseSolver.py
@@ -96,6 +96,8 @@ class TestOptions(unittest.TestCase):
         with self.assertRaises(Error):
             solver.getOption("invalidOption")  # test name checking
         with self.assertRaises(Error):
+            solver.setOption("invalidOption", 1)  # test name checking
+        with self.assertRaises(Error):
             solver.setOption("intOption", 4)  # test value not in list
         with self.assertRaises(Error):
             solver.setOption("intOption", "3")  # test type checking with list


### PR DESCRIPTION
## Purpose
This PR makes the error messages a bit more helpful when an invalid option is used. It uses the build in function `get_close_matches` to suggest the closest option name to the one entered.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
I added a new test

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
