### PR TITLE
Add metadata to BaseRegTest

### DIFF
--- a/baseclasses/BaseRegTest.py
+++ b/baseclasses/BaseRegTest.py
@@ -72,12 +72,12 @@ class BaseRegTest(object):
     def writeRef(self):
         with multi_proc_exception_check(self.comm):
             if self.rank == 0:
-                writeRefJSON(self.ref_file, self.db)
+                self.writeRefJSON(self.ref_file, self.db)
 
     def readRef(self):
         with multi_proc_exception_check(self.comm):
             if self.rank == 0:
-                db = readRefJSON(self.ref_file)
+                db = self.readRefJSON(self.ref_file)
             else:
                 db = None
             db = self.comm.bcast(db)
@@ -211,134 +211,134 @@ class BaseRegTest(object):
             else:
                 self._add_values(key, d[key], rtol=rtol, atol=atol, db=db[dict_name], full_name=full_name)
 
+    # =============================================================================
+    #                         reference files I/O
+    # =============================================================================
+    # based on this stack overflow answer https://stackoverflow.com/questions/3488934/simplejson-and-numpy-array/24375113#24375113
 
-# =============================================================================
-#                         reference files I/O
-# =============================================================================
+    @staticmethod
+    def writeRefJSON(file_name, ref):
+        class NumpyEncoder(json.JSONEncoder):
+            def default(self, obj):
+                """If input object is an ndarray it will be converted into a dict
+                holding dtype, shape and the data, base64 encoded.
+                """
+                if isinstance(obj, numpy.ndarray):
+                    if obj.flags["C_CONTIGUOUS"]:
+                        pass
+                    else:
+                        obj = numpy.ascontiguousarray(obj)
+                        assert obj.flags["C_CONTIGUOUS"]
+                    if obj.size == 1:
+                        return obj.item()
+                    else:
+                        return dict(__ndarray__=obj.tolist(), dtype=str(obj.dtype), shape=obj.shape)
+                elif isinstance(obj, numpy.integer):
+                    return dict(__ndarray__=int(obj), dtype=str(obj.dtype), shape=obj.shape)
+                elif isinstance(obj, numpy.floating):
+                    return dict(__ndarray__=float(obj), dtype=str(obj.dtype), shape=obj.shape)
 
-# based on this stack overflow answer https://stackoverflow.com/questions/3488934/simplejson-and-numpy-array/24375113#24375113
-def writeRefJSON(file_name, ref):
-    class NumpyEncoder(json.JSONEncoder):
-        def default(self, obj):
-            """If input object is an ndarray it will be converted into a dict
-            holding dtype, shape and the data, base64 encoded.
+                # Let the base class default method raise the TypeError
+                super(NumpyEncoder, self).default(obj)
+
+        with open(file_name, "w") as json_file:
+            json.dump(ref, json_file, sort_keys=True, indent=4, separators=(",", ": "), cls=NumpyEncoder)
+
+    # based on this stack overflow answer https://stackoverflow.com/questions/3488934/simplejson-and-numpy-array/24375113#24375113
+    @staticmethod
+    def readRefJSON(file_name):
+        def json_numpy_obj_hook(dct):
+            """Decodes a previously encoded numpy ndarray with proper shape and dtype.
+
+            :param dct: (dict) json encoded ndarray
+            :return: (ndarray) if input was an encoded ndarray
             """
-            if isinstance(obj, numpy.ndarray):
-                if obj.flags["C_CONTIGUOUS"]:
-                    pass
+            if isinstance(dct, dict) and "__ndarray__" in dct:
+                data = dct["__ndarray__"]
+                return numpy.array(data, dct["dtype"]).reshape(dct["shape"])
+            return dct
+
+        with open(file_name, "r") as json_file:
+            data = json.load(json_file, object_hook=json_numpy_obj_hook)
+
+        return data
+
+    @staticmethod
+    def convertRegFileToJSONRegFile(file_name, output_file=None):
+        """ converts from the old format of regression test file to the new JSON format"""
+
+        if output_file is None:
+            output_file = os.path.splitext(file_name)[0] + ".json"
+
+        ref = {}
+        line_history = deque(maxlen=3)
+
+        def saveValueInRef(value, key, mydict):
+            """a helper function to add values to our ref dict"""
+
+            if key in mydict:
+                # turn the value into a numpy array and append or just append if
+                # the value is already an numpy.array
+
+                if isinstance(mydict[key], numpy.ndarray):
+                    mydict[key] = numpy.append(mydict[key], value)
                 else:
-                    obj = numpy.ascontiguousarray(obj)
-                    assert obj.flags["C_CONTIGUOUS"]
-                if obj.size == 1:
-                    return obj.item()
-                else:
-                    return dict(__ndarray__=obj.tolist(), dtype=str(obj.dtype), shape=obj.shape)
-            elif isinstance(obj, numpy.integer):
-                return dict(__ndarray__=int(obj), dtype=str(obj.dtype), shape=obj.shape)
-            elif isinstance(obj, numpy.floating):
-                return dict(__ndarray__=float(obj), dtype=str(obj.dtype), shape=obj.shape)
-
-            # Let the base class default method raise the TypeError
-            super(NumpyEncoder, self).default(obj)
-
-    with open(file_name, "w") as json_file:
-        json.dump(ref, json_file, sort_keys=True, indent=4, separators=(",", ": "), cls=NumpyEncoder)
-
-
-# based on this stack overflow answer https://stackoverflow.com/questions/3488934/simplejson-and-numpy-array/24375113#24375113
-def readRefJSON(file_name):
-    def json_numpy_obj_hook(dct):
-        """Decodes a previously encoded numpy ndarray with proper shape and dtype.
-
-        :param dct: (dict) json encoded ndarray
-        :return: (ndarray) if input was an encoded ndarray
-        """
-        if isinstance(dct, dict) and "__ndarray__" in dct:
-            data = dct["__ndarray__"]
-            return numpy.array(data, dct["dtype"]).reshape(dct["shape"])
-        return dct
-
-    with open(file_name, "r") as json_file:
-        data = json.load(json_file, object_hook=json_numpy_obj_hook)
-
-    return data
-
-
-def convertRegFileToJSONRegFile(file_name, output_file=None):
-    """ converts from the old format of regression test file to the new JSON format"""
-
-    if output_file is None:
-        output_file = os.path.splitext(file_name)[0] + ".json"
-
-    ref = {}
-    line_history = deque(maxlen=3)
-
-    def saveValueInRef(value, key, mydict):
-        """a helper function to add values to our ref dict"""
-
-        if key in mydict:
-            # turn the value into a numpy array and append or just append if
-            # the value is already an numpy.array
-
-            if isinstance(mydict[key], numpy.ndarray):
-                mydict[key] = numpy.append(mydict[key], value)
+                    mydict[key] = numpy.array([mydict[key], value])
             else:
-                mydict[key] = numpy.array([mydict[key], value])
-        else:
-            mydict[key] = value
+                mydict[key] = value
 
-    curr_dict = ref
-    with open(file_name, "r") as fid:
-        for line in fid:
-            # key ideas
-            #    - lines starting with @value aren't added to the queque
+        curr_dict = ref
+        with open(file_name, "r") as fid:
+            for line in fid:
+                # key ideas
+                #    - lines starting with @value aren't added to the queque
 
-            # check to see if it is the start of dictionary of values
-            if "Dictionary Key: " in line:
+                # check to see if it is the start of dictionary of values
+                if "Dictionary Key: " in line:
 
-                # if there are other lines in the queque this isn't following
-                # an @value
-                if len(line_history) > 0:
+                    # if there are other lines in the queque this isn't following
+                    # an @value
+                    if len(line_history) > 0:
 
-                    # We must create a new dictionary and add it to ref
-                    last_line = line_history[-1].rstrip()
-                    if "Dictionary Key: " in last_line:
-                        # this is a nested dict
-                        key = last_line[len("Dictionary Key: ") :]
+                        # We must create a new dictionary and add it to ref
+                        last_line = line_history[-1].rstrip()
+                        if "Dictionary Key: " in last_line:
+                            # this is a nested dict
+                            key = last_line[len("Dictionary Key: ") :]
 
-                        if len(line_history) > 1:
-                            prior_dict = curr_dict
-                            curr_dict[key] = {}
-                            curr_dict = curr_dict[key]
+                            if len(line_history) > 1:
+                                prior_dict = curr_dict
+                                curr_dict[key] = {}
+                                curr_dict = curr_dict[key]
+                            else:
+                                prior_dict[key] = {}
+                                curr_dict = prior_dict[key]
+                            print("nested dict", last_line)
                         else:
-                            prior_dict[key] = {}
-                            curr_dict = prior_dict[key]
-                        print("nested dict", last_line)
-                    else:
-                        print("dict ", last_line)
-                        ref[last_line] = {}
-                        curr_dict = ref[last_line]
+                            print("dict ", last_line)
+                            ref[last_line] = {}
+                            curr_dict = ref[last_line]
 
-            if "@value" in line:
-                # get the value from the ref file
-                value = float(line.split()[1])
+                if "@value" in line:
+                    # get the value from the ref file
+                    value = float(line.split()[1])
 
-                # if a value was not just added
-                if line_history:
-                    # grab the data and use them as the keys for the reference dictionary
-                    key = line_history[-1].rstrip()
-                    if "Dictionary Key: " in key:
-                        key = key[len("Dictionary Key: ") :]
-                    else:
-                        curr_dict = ref
+                    # if a value was not just added
+                    if line_history:
+                        # grab the data and use them as the keys for the reference dictionary
+                        key = line_history[-1].rstrip()
+                        if "Dictionary Key: " in key:
+                            key = key[len("Dictionary Key: ") :]
+                        else:
+                            curr_dict = ref
 
-                saveValueInRef(value, key, curr_dict)
-                line_history.clear()
-            else:
-                # When deque reaches 2 lines, will automatically evict oldest
-                line_history.append(line)
+                    saveValueInRef(value, key, curr_dict)
+                    line_history.clear()
+                else:
+                    # When deque reaches 2 lines, will automatically evict oldest
+                    line_history.append(line)
 
-    writeRefJSON(output_file, ref)
+        BaseRegTest.writeRefJSON(output_file, ref)
 
 
 """This strategy of dealing with error propagation to multiple procs is taken directly form openMDAO.utils;

--- a/baseclasses/BaseSolver.py
+++ b/baseclasses/BaseSolver.py
@@ -6,6 +6,7 @@ Holds a basic Python Analysis Classes (base and inherited).
 from difflib import get_close_matches
 from pprint import pprint
 import copy
+import warnings
 from .utils import CaseInsensitiveDict, CaseInsensitiveSet, Error
 
 # =============================================================================
@@ -179,6 +180,10 @@ class BaseSolver(object):
             raise Error(f"{name} is not a valid option name. Perhaps you meant {guess}?")
 
     def printCurrentOptions(self):
+        self.printOptions()
+        warnings.warn("printCurrentOptions is deprecated. Use printOptions instead.", DeprecationWarning)
+
+    def printOptions(self):
         """
         Prints a nicely formatted dictionary of all the current solver
         options to the stdout on the root processor

--- a/baseclasses/BaseSolver.py
+++ b/baseclasses/BaseSolver.py
@@ -186,10 +186,10 @@ class BaseSolver(object):
         self.pp("+----------------------------------------+")
         self.pp("|" + f"All {self.name} Options:".center(40) + "|")
         self.pp("+----------------------------------------+")
-        options = self.getAllOptions()
+        options = self.getOptions()
         self.pp(options)
 
-    def getAllOptions(self):
+    def getOptions(self):
         return copy.copy(self.options)
 
     def getModifiedOptions(self):

--- a/baseclasses/BaseSolver.py
+++ b/baseclasses/BaseSolver.py
@@ -186,11 +186,25 @@ class BaseSolver(object):
         self.pp("+----------------------------------------+")
         self.pp("|" + f"All {self.name} Options:".center(40) + "|")
         self.pp("+----------------------------------------+")
-        # Need to assemble a temporary dictionary
-        tmpDict = {}
-        for key in self.options:
-            tmpDict[key] = self.getOption(key)
-        self.pp(tmpDict)
+        options = self.getAllOptions()
+        self.pp(options)
+
+    def getAllOptions(self):
+        options = {}
+        for key in self.options.keys():
+            options[key] = self.getOption(key)
+        return options
+
+    def getModifiedOptions(self):
+        modifiedOptions = {}
+        for key in self.options.keys():
+            defaultType, defaultValue = self.defaultOptions[key]
+            if defaultType is list and not isinstance(defaultValue, list):
+                defaultValue = defaultValue[0]
+            optionValue = self.getOption(key)
+            if optionValue != defaultValue:
+                modifiedOptions[key] = optionValue
+        return modifiedOptions
 
     def printModifiedOptions(self):
         """
@@ -201,16 +215,8 @@ class BaseSolver(object):
         self.pp("+----------------------------------------+")
         self.pp("|" + f"All Modified {self.name} Options:".center(40) + "|")
         self.pp("+----------------------------------------+")
-        # Need to assemble a temporary dictionary
-        tmpDict = {}
-        for key in self.options:
-            defaultType, defaultValue = self.defaultOptions[key]
-            if defaultType is list and not isinstance(defaultValue, list):
-                defaultValue = defaultValue[0]
-            optionValue = self.getOption(key)
-            if optionValue != defaultValue:
-                tmpDict[key] = optionValue
-        self.pp(tmpDict)
+        modifiedOptions = self.getModifiedOptions()
+        self.pp(modifiedOptions)
 
     def pp(self, obj):
         """

--- a/baseclasses/BaseSolver.py
+++ b/baseclasses/BaseSolver.py
@@ -5,6 +5,7 @@ Holds a basic Python Analysis Classes (base and inherited).
 """
 from difflib import get_close_matches
 from pprint import pprint
+import copy
 from .utils import CaseInsensitiveDict, CaseInsensitiveSet, Error
 
 # =============================================================================
@@ -182,7 +183,6 @@ class BaseSolver(object):
         Prints a nicely formatted dictionary of all the current solver
         options to the stdout on the root processor
         """
-
         self.pp("+----------------------------------------+")
         self.pp("|" + f"All {self.name} Options:".center(40) + "|")
         self.pp("+----------------------------------------+")
@@ -190,12 +190,13 @@ class BaseSolver(object):
         self.pp(options)
 
     def getAllOptions(self):
-        options = {}
-        for key in self.options.keys():
-            options[key] = self.getOption(key)
-        return options
+        return copy.copy(self.options)
 
     def getModifiedOptions(self):
+        """
+        Prints a nicely formatted dictionary of all the modified solver
+        options to the stdout on the root processor
+        """
         modifiedOptions = {}
         for key in self.options.keys():
             defaultType, defaultValue = self.defaultOptions[key]

--- a/baseclasses/__init__.py
+++ b/baseclasses/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.1"
+__version__ = "1.4.0"
 
 from .pyAero_problem import AeroProblem
 from .pyTransi_problem import TransiProblem

--- a/tests/test_BaseRegTest.py
+++ b/tests/test_BaseRegTest.py
@@ -90,11 +90,14 @@ class TestBaseRegTest(unittest.TestCase):
         Also tests read/write in the process
         """
         self.ref_file = os.path.join(baseDir, "test_root.ref")
+        metadata = {"options": None}
         with BaseRegTest(self.ref_file, train=True) as handler:
             self.regression_test_root(handler)
+            handler.add_metadata(metadata)
         test_vals = handler.readRef()
         # check the two values match
         self.assertEqual(test_vals, root_vals)
+        self.assertEqual(handler.get_metadata(), metadata)
 
         # test train=False
         handler = BaseRegTest(self.ref_file, train=False)

--- a/tests/test_BaseRegTest.py
+++ b/tests/test_BaseRegTest.py
@@ -94,6 +94,9 @@ class TestBaseRegTest(unittest.TestCase):
         with BaseRegTest(self.ref_file, train=True) as handler:
             self.regression_test_root(handler)
             handler.add_metadata(metadata)
+            # More added at later stage, like version
+            metadata["version"] = "1.2.3"
+            handler.add_metadata(metadata)
         test_vals = handler.readRef()
         # check the two values match
         self.assertEqual(test_vals, root_vals)

--- a/tests/test_BaseSolver.py
+++ b/tests/test_BaseSolver.py
@@ -140,7 +140,7 @@ class TestComm(unittest.TestCase):
         # initialize solver
         solver = SOLVER("testComm", comm=None)
         self.assertTrue(solver.comm is None)
-        solver.printCurrentOptions()
+        solver.printCurrentOptions()  # this should print current options twice since comm is not set
 
 
 class TestInforms(unittest.TestCase):

--- a/tests/test_BaseSolver.py
+++ b/tests/test_BaseSolver.py
@@ -140,7 +140,7 @@ class TestComm(unittest.TestCase):
         # initialize solver
         solver = SOLVER("testComm", comm=None)
         self.assertTrue(solver.comm is None)
-        solver.printCurrentOptions()  # this should print current options twice since comm is not set
+        solver.printCurrentOptions()  # this should print current options twice since comm is not set and N_PROCS=2
 
 
 class TestInforms(unittest.TestCase):

--- a/tests/test_BaseSolver.py
+++ b/tests/test_BaseSolver.py
@@ -56,7 +56,7 @@ class TestOptions(unittest.TestCase):
         intValue_set = 3
         options = {"floatOption": floatValue_set, "intOption": intValue_set}
         solver = SOLVER("test", options=options)
-        solver.printCurrentOptions()
+        solver.printOptions()
 
         # test getOption for initialized option
         floatValue_get = solver.getOption("floatOption")
@@ -134,13 +134,13 @@ class TestComm(unittest.TestCase):
         # initialize solver
         solver = SOLVER("testComm", comm=MPI.COMM_WORLD)
         self.assertFalse(solver.comm is None)
-        solver.printCurrentOptions()
+        solver.printOptions()
 
     def test_comm_without_mpi(self):
         # initialize solver
         solver = SOLVER("testComm", comm=None)
         self.assertTrue(solver.comm is None)
-        solver.printCurrentOptions()  # this should print current options twice since comm is not set and N_PROCS=2
+        solver.printOptions()  # this should print current options twice since comm is not set and N_PROCS=2
 
 
 class TestInforms(unittest.TestCase):


### PR DESCRIPTION
## Purpose
This PR adds the ability for BaseRegTest to store metadata. This is a dictionary which is never used in testing, i.e. compared, but is used to store auxiliary information such as solver options. If present, it will be stored as the last key in the JSON file, and can be added/retrieved via dedicated API.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
I have added a test to highlight the usage.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
