### PR TITLE
Updated containers to preserve capitalization on initialization

### DIFF
--- a/baseclasses/utils.py
+++ b/baseclasses/utils.py
@@ -14,9 +14,9 @@ class CaseInsensitiveDict(dict):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._updateMaps()
+        self._updateMap()
 
-    def _updateMaps(self):
+    def _updateMap(self):
         """
         This function updates self.map based on self.keys().
         """
@@ -81,7 +81,7 @@ class CaseInsensitiveDict(dict):
 
     def update(self, d, *args, **kwargs):
         super().update(d, *args, **kwargs)
-        self._updateMaps()
+        self._updateMap()
 
 
 class CaseInsensitiveSet(set):
@@ -100,9 +100,9 @@ class CaseInsensitiveSet(set):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._updateMaps()
+        self._updateMap()
 
-    def _updateMaps(self):
+    def _updateMap(self):
         self.map = {k.lower(): k for k in list(self)}
 
     def _getItem(self, item):
@@ -142,7 +142,7 @@ class CaseInsensitiveSet(set):
 
     def update(self, d, *args, **kwargs):
         super().update(d, *args, **kwargs)
-        self._updateMaps()
+        self._updateMap()
 
     def issubset(self, other):
         lowerSelf = set([s.lower() for s in self])

--- a/baseclasses/utils.py
+++ b/baseclasses/utils.py
@@ -9,28 +9,79 @@ class CaseInsensitiveDict(dict):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # convert keys to lower case
-        for k in list(self.keys()):
-            v = super().pop(k)
-            self.__setitem__(k, v)
+        self._updateMaps()
+
+    def _updateMaps(self):
+        """
+        This function updates the self.map and self.invMap
+        dictionaries based on self.keys().
+        """
+        self.map = {k: k.lower() for k in self.keys()}
+        self.invMap = {v: k for k, v in self.map.items()}
+
+    def _getKey(self, key):
+        """
+        This function checks if the input key already exists.
+        Note that this check is case insensitive
+
+        Parameters
+        ----------
+        key : str
+            the key to check
+
+        Returns
+        -------
+        str, None
+            Returns the original key if it exists. Otherwise returns None.
+        """
+        if key.lower() in self.invMap:
+            return self.invMap[key.lower()]
+        else:
+            return None
 
     def __setitem__(self, key, value):
-        super().__setitem__(key.lower(), value)
+        existingKey = self._getKey(key)
+        if existingKey:
+            key = existingKey
+        else:
+            self.map[key] = key.lower()
+            self.invMap[key.lower()] = key
+        super().__setitem__(key, value)
 
     def __getitem__(self, key):
-        return super().__getitem__(key.lower())
+        existingKey = self._getKey(key)
+        if existingKey:
+            key = existingKey
+        return super().__getitem__(key)
 
     def __contains__(self, key):
-        return super().__contains__(key.lower())
+        return key.lower() in self.invMap.keys()
 
     def __delitem__(self, key):
-        super().__delitem__(key.lower())
+        existingKey = self._getKey(key)
+        if existingKey:
+            key = existingKey
+            self.map.pop(existingKey)
+            self.invMap.pop(key.lower())
+        super().__delitem__(key)
 
     def pop(self, key, *args, **kwargs):
-        super().pop(key.lower(), *args, **kwargs)
+        existingKey = self._getKey(key)
+        if existingKey:
+            key = existingKey
+            self.map.pop(existingKey)
+            self.invMap.pop(key.lower())
+        super().pop(key, *args, **kwargs)
 
     def get(self, key, *args, **kwargs):
-        return super().get(key.lower(), *args, **kwargs)
+        existingKey = self._getKey(key)
+        if existingKey:
+            key = existingKey
+        return super().get(key, *args, **kwargs)
+
+    def update(self, d, *args, **kwargs):
+        super().update(d, *args, **kwargs)
+        self._updateMaps()
 
 
 class CaseInsensitiveSet(set):

--- a/baseclasses/utils.py
+++ b/baseclasses/utils.py
@@ -95,20 +95,20 @@ class CaseInsensitiveSet(set):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._updateMap()
+        self._updateMaps()
 
-    def _updateMap(self):
-        self.map = {k: k.lower() for k in self.items()}
+    def _updateMaps(self):
+        self.map = {k: k.lower() for k in list(self)}
         self.invMap = {v: k for k, v in self.map.items()}
 
     def _getItem(self, item):
         """
-        This function checks if the input key already exists.
+        This function checks if the input item already exists.
         Note that this check is case insensitive
 
         Parameters
         ----------
-        key : str
+        item : str
             the item to check
 
         Returns
@@ -125,13 +125,44 @@ class CaseInsensitiveSet(set):
         existingItem = self._getItem(item)
         if existingItem:
             item = existingItem
-        super().add(item.lower())
+        else:
+            self.map[item] = item.lower()
+            self.invMap[item.lower()] = item
+        super().add(item)
 
-    def __contains__(self, item):
+    def pop(self, item, *args, **kwargs):
         existingItem = self._getItem(item)
         if existingItem:
             item = existingItem
-        return super().__contains__(item.lower())
+            self.map.pop(existingItem)
+            self.invMap.pop(item.lower())
+        super().pop(item, *args, **kwargs)
+
+    def update(self, d, *args, **kwargs):
+        super().update(d, *args, **kwargs)
+        self._updateMaps()
+
+    def issubset(self, other):
+        lowerSelf = set([s.lower() for s in self])
+        lowerOther = set([s.lower() for s in other])
+        return lowerSelf.issubset(lowerOther)
+
+    def remove(self, item):
+        existingItem = self._getItem(item)
+        if existingItem:
+            item = existingItem
+            self.map.pop(existingItem)
+            self.invMap.pop(item.lower())
+        super().remove(item)
+        print(self)
+
+    def __contains__(self, item):
+        return item.lower() in self.invMap.keys()
+
+    def __eq__(self, other):
+        a = set([s.lower() for s in list(self)])
+        b = set([o.lower() for o in list(other)])
+        return a.__eq__(b)
 
 
 class Error(Exception):

--- a/baseclasses/utils.py
+++ b/baseclasses/utils.py
@@ -5,6 +5,11 @@ class CaseInsensitiveDict(dict):
     create an instance where keys are not strings.
     All common Python dictionary operations are supported, and additional operations
     can be added easily.
+    In order to preserve capitalization on key initialization, the implementation relies on storing
+    a dictionary of mappings between the initial capitalization and the lowercase representation.
+    This is stored in self.map, along with the inverse in self.invMap.
+    By looking up in these mappings, we can check any new keys against existing keys and compare them
+    in a case-insensitive fashion.
     """
 
     def __init__(self, *args, **kwargs):
@@ -91,6 +96,11 @@ class CaseInsensitiveSet(set):
     create an instance where elements are not strings.
     All common Python set operations are supported, and additional operations
     can be added easily.
+    In order to preserve capitalization on key initialization, the implementation relies on storing
+    a dictionary of mappings between the initial capitalization and the lowercase representation.
+    This is stored in self.map, along with the inverse in self.invMap.
+    By looking up in these mappings, we can check any new keys against existing keys and compare them
+    in a case-insensitive fashion.
     """
 
     def __init__(self, *args, **kwargs):

--- a/baseclasses/utils.py
+++ b/baseclasses/utils.py
@@ -164,7 +164,6 @@ class CaseInsensitiveSet(set):
             self.map.pop(existingItem)
             self.invMap.pop(item.lower())
         super().remove(item)
-        print(self)
 
     def __contains__(self, item):
         return item.lower() in self.invMap.keys()

--- a/baseclasses/utils.py
+++ b/baseclasses/utils.py
@@ -95,15 +95,42 @@ class CaseInsensitiveSet(set):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # convert entries to lowe case
-        for k in self:
-            super().remove(k)
-            self.add(k)
+        self._updateMap()
+
+    def _updateMap(self):
+        self.map = {k: k.lower() for k in self.items()}
+        self.invMap = {v: k for k, v in self.map.items()}
+
+    def _getItem(self, item):
+        """
+        This function checks if the input key already exists.
+        Note that this check is case insensitive
+
+        Parameters
+        ----------
+        key : str
+            the item to check
+
+        Returns
+        -------
+        str, None
+            Returns the original item if it exists. Otherwise returns None.
+        """
+        if item.lower() in self.invMap:
+            return self.invMap[item.lower()]
+        else:
+            return None
 
     def add(self, item):
+        existingItem = self._getItem(item)
+        if existingItem:
+            item = existingItem
         super().add(item.lower())
 
     def __contains__(self, item):
+        existingItem = self._getItem(item)
+        if existingItem:
+            item = existingItem
         return super().__contains__(item.lower())
 
 

--- a/baseclasses/utils.py
+++ b/baseclasses/utils.py
@@ -6,8 +6,8 @@ class CaseInsensitiveDict(dict):
     All common Python dictionary operations are supported, and additional operations
     can be added easily.
     In order to preserve capitalization on key initialization, the implementation relies on storing
-    a dictionary of mappings between the initial capitalization and the lowercase representation.
-    This is stored in self.map, along with the inverse in self.invMap.
+    a dictionary of mappings between the lowercase representation and the initial capitalization,
+    which is stored in self.map.
     By looking up in these mappings, we can check any new keys against existing keys and compare them
     in a case-insensitive fashion.
     """
@@ -18,11 +18,9 @@ class CaseInsensitiveDict(dict):
 
     def _updateMaps(self):
         """
-        This function updates the self.map and self.invMap
-        dictionaries based on self.keys().
+        This function updates self.map based on self.keys().
         """
-        self.map = {k: k.lower() for k in self.keys()}
-        self.invMap = {v: k for k, v in self.map.items()}
+        self.map = {k.lower(): k for k in self.keys()}
 
     def _getKey(self, key):
         """
@@ -39,8 +37,8 @@ class CaseInsensitiveDict(dict):
         str, None
             Returns the original key if it exists. Otherwise returns None.
         """
-        if key.lower() in self.invMap:
-            return self.invMap[key.lower()]
+        if key.lower() in self.map:
+            return self.map[key.lower()]
         else:
             return None
 
@@ -49,8 +47,7 @@ class CaseInsensitiveDict(dict):
         if existingKey:
             key = existingKey
         else:
-            self.map[key] = key.lower()
-            self.invMap[key.lower()] = key
+            self.map[key.lower()] = key
         super().__setitem__(key, value)
 
     def __getitem__(self, key):
@@ -60,22 +57,20 @@ class CaseInsensitiveDict(dict):
         return super().__getitem__(key)
 
     def __contains__(self, key):
-        return key.lower() in self.invMap.keys()
+        return key.lower() in self.map.keys()
 
     def __delitem__(self, key):
         existingKey = self._getKey(key)
         if existingKey:
             key = existingKey
-            self.map.pop(existingKey)
-            self.invMap.pop(key.lower())
+            self.map.pop(key.lower())
         super().__delitem__(key)
 
     def pop(self, key, *args, **kwargs):
         existingKey = self._getKey(key)
         if existingKey:
             key = existingKey
-            self.map.pop(existingKey)
-            self.invMap.pop(key.lower())
+            self.map.pop(key.lower())
         super().pop(key, *args, **kwargs)
 
     def get(self, key, *args, **kwargs):
@@ -97,8 +92,8 @@ class CaseInsensitiveSet(set):
     All common Python set operations are supported, and additional operations
     can be added easily.
     In order to preserve capitalization on key initialization, the implementation relies on storing
-    a dictionary of mappings between the initial capitalization and the lowercase representation.
-    This is stored in self.map, along with the inverse in self.invMap.
+    a dictionary of mappings between the lowercase representation and the initial capitalization,
+    which is stored in self.map.
     By looking up in these mappings, we can check any new keys against existing keys and compare them
     in a case-insensitive fashion.
     """
@@ -108,8 +103,7 @@ class CaseInsensitiveSet(set):
         self._updateMaps()
 
     def _updateMaps(self):
-        self.map = {k: k.lower() for k in list(self)}
-        self.invMap = {v: k for k, v in self.map.items()}
+        self.map = {k.lower(): k for k in list(self)}
 
     def _getItem(self, item):
         """
@@ -126,8 +120,8 @@ class CaseInsensitiveSet(set):
         str, None
             Returns the original item if it exists. Otherwise returns None.
         """
-        if item.lower() in self.invMap:
-            return self.invMap[item.lower()]
+        if item.lower() in self.map:
+            return self.map[item.lower()]
         else:
             return None
 
@@ -136,16 +130,14 @@ class CaseInsensitiveSet(set):
         if existingItem:
             item = existingItem
         else:
-            self.map[item] = item.lower()
-            self.invMap[item.lower()] = item
+            self.map[item.lower()] = item
         super().add(item)
 
     def pop(self, item, *args, **kwargs):
         existingItem = self._getItem(item)
         if existingItem:
             item = existingItem
-            self.map.pop(existingItem)
-            self.invMap.pop(item.lower())
+            self.map.pop(item.lower())
         super().pop(item, *args, **kwargs)
 
     def update(self, d, *args, **kwargs):
@@ -161,12 +153,11 @@ class CaseInsensitiveSet(set):
         existingItem = self._getItem(item)
         if existingItem:
             item = existingItem
-            self.map.pop(existingItem)
-            self.invMap.pop(item.lower())
+            self.map.pop(item.lower())
         super().remove(item)
 
     def __contains__(self, item):
-        return item.lower() in self.invMap.keys()
+        return item.lower() in self.map.keys()
 
     def __eq__(self, other):
         a = set([s.lower() for s in list(self)])

--- a/tests/test_BaseSolver.py
+++ b/tests/test_BaseSolver.py
@@ -95,10 +95,10 @@ class TestOptions(unittest.TestCase):
         # test Errors
         with self.assertRaises(Error) as context:
             solver.getOption("invalidOption")  # test invalid option in getOption
-        self.assertTrue("intoption" in context.exception.message)  # check that intoption is offered as a suggestion
+        self.assertTrue("intOption" in context.exception.message)  # check that intoption is offered as a suggestion
         with self.assertRaises(Error) as context:
             solver.setOption("invalidOption", 1)  # test invalid option in setOption
-        self.assertTrue("intoption" in context.exception.message)  # check that intoption is offered as a suggestion
+        self.assertTrue("intOption" in context.exception.message)  # check that intoption is offered as a suggestion
         with self.assertRaises(Error):
             solver.setOption("intOption", 4)  # test value not in list
         with self.assertRaises(Error):

--- a/tests/test_CaseInsensitve.py
+++ b/tests/test_CaseInsensitve.py
@@ -13,14 +13,14 @@ class TestCaseInsensitiveClasses(unittest.TestCase):
         # test __setitem__
         d["OPTION1"] = value2
         self.assertEqual(d["option1"], value2)
-        self.assertIn("OPtion1", d.map)
+        self.assertEqual("OPtion1", d.map["option1"])
         # test __contains__
         self.assertIn("Option1", d)
         d["optioN2"] = value1
         self.assertEqual(len(d), 2)
         self.assertIn("OPTION2", d)
         # test original capitalization is preserved on new key
-        self.assertIn("optioN2", d.map)
+        self.assertEqual("optioN2", d.map["option2"])
         # test pop()
         d.pop("Option2")
         self.assertEqual(len(d), 1)
@@ -37,11 +37,11 @@ class TestCaseInsensitiveClasses(unittest.TestCase):
         s = CaseInsensitiveSet({"Option1"})
         self.assertIn("OPTION1", s)
         # test original capitalization is preserved on initialization
-        self.assertIn("Option1", s.map)
+        self.assertEqual("Option1", s.map["option1"])
         s.add("OPTION2")
         self.assertIn("option2", s)
         # test original capitalization is preserved on new item
-        self.assertIn("OPTION2", s.map)
+        self.assertEqual("OPTION2", s.map["option2"])
         # test update()
         s2 = CaseInsensitiveSet({"OPTION2", "opTION3"})
         s.update(s2)

--- a/tests/test_CaseInsensitve.py
+++ b/tests/test_CaseInsensitve.py
@@ -22,7 +22,7 @@ class TestCaseInsensitiveClasses(unittest.TestCase):
         d.pop("Option2")
         self.assertEqual(len(d), 1)
         self.assertEqual(d.get("opTION1"), value2)
-        self.assertEqual(list(d), ["option1"])
+        self.assertEqual(list(d), ["OPtion1"])
         d2 = CaseInsensitiveDict({"OPTION3": value3})
         # test update()
         d.update(d2)

--- a/tests/test_CaseInsensitve.py
+++ b/tests/test_CaseInsensitve.py
@@ -13,11 +13,14 @@ class TestCaseInsensitiveClasses(unittest.TestCase):
         # test __setitem__
         d["OPTION1"] = value2
         self.assertEqual(d["option1"], value2)
+        self.assertIn("OPtion1", d.map)
         # test __contains__
         self.assertIn("Option1", d)
-        d["option2"] = value1
+        d["optioN2"] = value1
         self.assertEqual(len(d), 2)
         self.assertIn("OPTION2", d)
+        # test original capitalization is preserved on new key
+        self.assertIn("optioN2", d.map)
         # test pop()
         d.pop("Option2")
         self.assertEqual(len(d), 1)
@@ -33,8 +36,12 @@ class TestCaseInsensitiveClasses(unittest.TestCase):
         # test __contains__ and add()
         s = CaseInsensitiveSet({"Option1"})
         self.assertIn("OPTION1", s)
+        # test original capitalization is preserved on initialization
+        self.assertIn("Option1", s.map)
         s.add("OPTION2")
         self.assertIn("option2", s)
+        # test original capitalization is preserved on new item
+        self.assertIn("OPTION2", s.map)
         # test update()
         s2 = CaseInsensitiveSet({"OPTION2", "opTION3"})
         s.update(s2)


### PR DESCRIPTION
## Purpose
Closes #37.
The implementation involves storing `self.map` which contains a dictionary for looking up the lower-case and capitalized keys. Any time a new key is added (initialization or subsequently) that capitalization is preserved and cannot be changed, but all comparisons are done with the lower-case values.

Now, for example when printing the options, you get:
```
'+----------------------------------------+'
'|           All test Options:            |'
'+----------------------------------------+'
{'boolOption': True,
 'floatOption': 200.0,
 'intOption': 3,
 'listOption': [],
 'multiOption': {},
 'strOption': 'str1'}
```
where capitalization from initialization is maintained.


## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
I slightly modified the existing tests.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
