### PR TITLE
Fixed bcast error

### DIFF
--- a/baseclasses/utils.py
+++ b/baseclasses/utils.py
@@ -83,6 +83,10 @@ class CaseInsensitiveDict(dict):
         super().update(d, *args, **kwargs)
         self._updateMap()
 
+    def __new__(self, *args, **kwargs):
+        self.map = {}
+        return super().__new__(self)
+
 
 class CaseInsensitiveSet(set):
     """

--- a/baseclasses/utils.py
+++ b/baseclasses/utils.py
@@ -84,6 +84,10 @@ class CaseInsensitiveDict(dict):
         self._updateMap()
 
     def __new__(self, *args, **kwargs):
+        """
+        This is a custom __new__ implementation. All it does is set self.map to an empty dictionary.
+        This is here so the class instance can be pickled, and therefore used by mpi4py for bcast etc.
+        """
         self.map = {}
         return super().__new__(self)
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ setup(
     install_requires=[
         "numpy>=1.16",
     ],
+    extras_require={
+        "testing": ["testflo", "parameterized"],
+    },
     classifiers=[
         "Operating System :: OS Independent",
         "Topic :: Scientific/Engineering",


### PR DESCRIPTION
## Purpose
Changes in #38 (specifically the fact that `__setitem__` and `__getitem__` now require the `self.map` attribute) meant that MPI operations based on pickling failed. I'm not entirely sure what's going on, but I suspect it's something to do with the fact that `self.map` is not available when picking these methods (maybe [the note here](https://docs.python.org/3/library/pickle.html#object.__setstate__) is relevant). Anyways, I had to implement `__new__` as suggested and now it works. I have added a bcast test. Note that `CaseInsensitiveSet` is unaffected since it does not have these two methods. I have no idea why these two methods specifically were causing problems...

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
I have added two tests.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
