### PR TITLE
changed pp to use pprint only if obj is not string

### DIFF
--- a/baseclasses/BaseSolver.py
+++ b/baseclasses/BaseSolver.py
@@ -235,4 +235,7 @@ class BaseSolver(object):
             any Python object to be printed
         """
         if (self.comm is not None and self.comm.rank == 0) or self.comm is None:
-            pprint(obj)
+            if isinstance(obj, str):
+                print(obj)
+            else:
+                pprint(obj)


### PR DESCRIPTION
## Purpose
For strings, `BaseSolver.pp()` should call `print` if `obj` is a string, otherwise call `pprint`.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
