### PR TITLE
Updated optional dependencies

### DIFF
--- a/baseclasses/BaseRegTest.py
+++ b/baseclasses/BaseRegTest.py
@@ -39,16 +39,15 @@ def getTol(**kwargs):
 class BaseRegTest(object):
     def __init__(self, ref_file, train=False, comm=None, check_arch=False):
         self.ref_file = ref_file
-        if comm is not None:
-            self.comm = comm
-            self.rank = self.comm.rank
+        if MPI is None:
+            self.comm = None
+            self.rank = 0
         else:
-            if MPI is None:
-                self.comm = None
-                self.rank = 0
+            if comm is not None:
+                self.comm = comm
             else:
                 self.comm = MPI.COMM_WORLD
-                self.rank = self.comm.rank
+            self.rank = self.comm.rank
 
         self.train = train
         if self.train:

--- a/baseclasses/__init__.py
+++ b/baseclasses/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 from .pyAero_problem import AeroProblem
 from .pyTransi_problem import TransiProblem

--- a/baseclasses/pyWeight_problem.py
+++ b/baseclasses/pyWeight_problem.py
@@ -10,7 +10,7 @@ import copy
 try:
     from pygeo import geo_utils
 except ImportError:
-    print("Warning: unable to find pygeo module, some functionality in pyWeight_problem will be unavailable")
+    geo_utils = None
 from .utils import Error
 
 
@@ -137,7 +137,10 @@ class WeightProblem(object):
             self.v1 = numpy.array(surf[1])
             self.v2 = numpy.array(surf[2])
         else:
-            self._generateDiscreteSurface(surf)
+            if geo_utils is None:
+                raise Error("Unable to find pygeo module, which is required for this functionality.")
+            else:
+                self._generateDiscreteSurface(surf)
 
     def _generateDiscreteSurface(self, geo):
         """

--- a/tests/test_CaseInsensitve.py
+++ b/tests/test_CaseInsensitve.py
@@ -173,8 +173,8 @@ class TestCaseInsensitiveSet(unittest.TestCase):
 class TestParallel(unittest.TestCase):
     N_PROCS = 2
 
-    @unittest.skipIf(MPI is None, "mpi4py not imported")
     @parameterized.expand(["CaseInsensitiveDict", "CaseInsensitiveSet"])
+    @unittest.skipIf(MPI is None, "mpi4py not imported")
     def test_bcast(self, class_type):
         comm = MPI.COMM_WORLD
         d = {"OPtion1": 1}


### PR DESCRIPTION
## Purpose
`baseclasses` has two optional dependencies:
- `pygeo` used by `WeightProblem`
- `mpi4py` used by `BaseRegTest`

However, both of these are optional, i.e. there are some functionalities in these classes that can be used without the additional module. This PR improves this by suppressing the warning until the function requiring the optional dependency is actually called, whereby an Error is raised. I also fixed `BaseRegTest` which basically didn't work previously without `mpi4py`.

This PR is motivated by mdolab/pyoptsparse#213.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
No new tests, but I verified that the same tests pass in an environment without `pygeo` or `mpi4py`.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
