### PR TITLE
Updated containers to use ABC

### DIFF
--- a/baseclasses/pyMission_problem.py
+++ b/baseclasses/pyMission_problem.py
@@ -514,8 +514,8 @@ class MissionSegment(object):
 
     This is the basic building block of the mission solver.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     phase : str
         Segment type selector valid options include
 

--- a/baseclasses/utils.py
+++ b/baseclasses/utils.py
@@ -1,4 +1,5 @@
 from collections.abc import MutableMapping, MutableSet
+from typing import Any, Dict, Optional
 
 
 class CaseInsensitiveDict(MutableMapping):
@@ -16,10 +17,12 @@ class CaseInsensitiveDict(MutableMapping):
     """
 
     def __init__(self, *args, **kwargs):
-        self.data = dict(*args, **kwargs)
-        self.map = {k.lower(): k for k in self.data.keys()}
+        self.data: dict = dict(*args, **kwargs)
+        if not all([isinstance(i, str) for i in self.data]):
+            raise ValueError("All keys must be strings!")
+        self.map: Dict[str, str] = {k.lower(): k for k in self.data.keys()}
 
-    def _getKey(self, key):
+    def _getKey(self, key: str):
         """
         This function checks if the input key already exists.
         Note that this check is case insensitive
@@ -39,18 +42,18 @@ class CaseInsensitiveDict(MutableMapping):
         else:
             return None
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: Any):
         existingKey = self._getKey(key)
         if existingKey:
             key = existingKey
         self.data[key] = value
         self.map[key.lower()] = key
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Any:
         existingKey = self._getKey(key)
         return self.data[existingKey]
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: str):
         existingKey = self._getKey(key)
         if existingKey:
             self.map.pop(existingKey.lower())
@@ -59,10 +62,10 @@ class CaseInsensitiveDict(MutableMapping):
     def __iter__(self):
         return iter(self.data)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.data.keys())
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         selfLower = {k.lower(): v for k, v in self.items()}
         otherLower = {k.lower(): v for k, v in other.items()}
         return selfLower.__eq__(otherLower)
@@ -83,10 +86,12 @@ class CaseInsensitiveSet(MutableSet):
     """
 
     def __init__(self, *args, **kwargs):
-        self.data = set(*args, **kwargs)
-        self.map = {k.lower(): k for k in list(self)}
+        self.data: set = set(*args, **kwargs)
+        if not all([isinstance(i, str) for i in self.data]):
+            raise ValueError("All items must be strings!")
+        self.map: Dict[str, str] = {k.lower(): k for k in list(self)}
 
-    def _getItem(self, item):
+    def _getItem(self, item: str) -> Optional[str]:
         """
         This function checks if the input item already exists.
         Note that this check is case insensitive
@@ -103,8 +108,10 @@ class CaseInsensitiveSet(MutableSet):
         """
         if item.lower() in self.map:
             return self.map[item.lower()]
+        else:
+            return None
 
-    def add(self, item):
+    def add(self, item: str):
         existingItem = self._getItem(item)
         if existingItem:
             item = existingItem
@@ -112,22 +119,22 @@ class CaseInsensitiveSet(MutableSet):
             self.map[item.lower()] = item
             self.data.add(item)
 
-    def __contains__(self, item):
+    def __contains__(self, item) -> bool:
         return item.lower() in self.map.keys()
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         """We convert both to regular set, and compare their lower case values"""
         a = set([s.lower() for s in list(self)])
         b = set([o.lower() for o in list(other)])
         return a.__eq__(b)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.data)
 
     def __iter__(self):
         return iter(self.data)
 
-    def discard(self, item):
+    def discard(self, item: str):
         existingItem = self._getItem(item)
         if existingItem:
             item = existingItem
@@ -149,7 +156,7 @@ class CaseInsensitiveSet(MutableSet):
         for item in d:
             self.add(item)
 
-    def issubset(self, other):
+    def issubset(self, other) -> bool:
         lowerSelf = set([s.lower() for s in self])
         lowerOther = set([s.lower() for s in other])
         return lowerSelf.issubset(lowerOther)

--- a/baseclasses/utils.py
+++ b/baseclasses/utils.py
@@ -33,7 +33,7 @@ class CaseInsensitiveDict(MutableMapping):
             raise ValueError("All keys must be strings!")
         self.map: Dict[str, str] = {k.lower(): k for k in self.data.keys()}
 
-    def _getKey(self, key: str):
+    def _getKey(self, key: str, raiseError=False):
         """
         This function checks if the input key already exists.
         Note that this check is case insensitive
@@ -51,6 +51,8 @@ class CaseInsensitiveDict(MutableMapping):
         if key.lower() in self.map:
             return self.map[key.lower()]
         else:
+            if raiseError:
+                raise KeyError(f"Key '{key}' not found.")
             return None
 
     def __setitem__(self, key: str, value: Any):
@@ -63,15 +65,11 @@ class CaseInsensitiveDict(MutableMapping):
         self.map[key.lower()] = key
 
     def __getitem__(self, key: str) -> Any:
-        existingKey = self._getKey(key)
-        if existingKey is None:
-            raise KeyError(f"Key '{key}' not found.")
+        existingKey = self._getKey(key, raiseError=True)
         return self.data[existingKey]
 
     def __delitem__(self, key: str):
-        existingKey = self._getKey(key)
-        if existingKey is None:
-            raise KeyError(f"Key '{key}' not found.")
+        existingKey = self._getKey(key, raiseError=True)
         self.map.pop(existingKey.lower())
         self.data.pop(existingKey)
 
@@ -155,6 +153,8 @@ class CaseInsensitiveSet(MutableSet):
 
     def __eq__(self, other) -> bool:
         """We convert both to regular set, and compare their lower case values"""
+        if not all([isinstance(i, str) for i in other]):
+            raise ValueError("All items must be strings!")
         a = set([s.lower() for s in list(self)])
         b = set([o.lower() for o in list(other)])
         return a.__eq__(b)

--- a/baseclasses/utils.py
+++ b/baseclasses/utils.py
@@ -85,6 +85,9 @@ class CaseInsensitiveDict(MutableMapping):
         otherLower = {k.lower(): v for k, v in other.items()}
         return selfLower.__eq__(otherLower)
 
+    def __repr__(self):
+        return str(self.data)
+
 
 class CaseInsensitiveSet(MutableSet):
     """
@@ -190,6 +193,9 @@ class CaseInsensitiveSet(MutableSet):
         lowerSelf = set([s.lower() for s in self])
         lowerOther = set([s.lower() for s in other])
         return lowerSelf.issubset(lowerOther)
+
+    def __repr__(self):
+        return str(self.data)
 
 
 class Error(Exception):

--- a/baseclasses/utils.py
+++ b/baseclasses/utils.py
@@ -30,7 +30,7 @@ class CaseInsensitiveDict(MutableMapping):
     def __init__(self, *args, **kwargs):
         self.data: dict = dict(*args, **kwargs)
         if not all([isinstance(i, str) for i in self.data]):
-            raise ValueError("All keys must be strings!")
+            raise TypeError("All keys must be strings!")
         self.map: Dict[str, str] = {k.lower(): k for k in self.data.keys()}
 
     def _getKey(self, key: str, raiseError=False):
@@ -42,11 +42,18 @@ class CaseInsensitiveDict(MutableMapping):
         ----------
         key : str
             the key to check
+        raiseError : bool
+            if true, raise KeyError if ``key`` is not found.
 
         Returns
         -------
         str, None
             Returns the original key if it exists. Otherwise returns None.
+
+        Raises
+        ------
+        KeyError
+            If ``raiseError`` and key is not found.
         """
         if key.lower() in self.map:
             return self.map[key.lower()]
@@ -57,7 +64,7 @@ class CaseInsensitiveDict(MutableMapping):
 
     def __setitem__(self, key: str, value: Any):
         if not isinstance(key, str):
-            raise ValueError("All keys must be strings.")
+            raise TypeError("All keys must be strings.")
         existingKey = self._getKey(key)
         if existingKey:
             key = existingKey
@@ -117,7 +124,7 @@ class CaseInsensitiveSet(MutableSet):
     def __init__(self, *args, **kwargs):
         self.data: set = set(*args, **kwargs)
         if not all([isinstance(i, str) for i in self.data]):
-            raise ValueError("All items must be strings!")
+            raise TypeError("All items must be strings!")
         self.map: Dict[str, str] = {k.lower(): k for k in list(self)}
 
     def _getItem(self, item: str) -> Optional[str]:
@@ -142,7 +149,7 @@ class CaseInsensitiveSet(MutableSet):
 
     def add(self, item: str):
         if not isinstance(item, str):
-            raise ValueError("All keys must be strings.")
+            raise TypeError("All keys must be strings.")
         existingItem = self._getItem(item)
         # don't do anything if it exists
         if not existingItem:
@@ -151,13 +158,13 @@ class CaseInsensitiveSet(MutableSet):
 
     def __contains__(self, item) -> bool:
         if not isinstance(item, str):
-            raise ValueError("All keys must be strings.")
+            raise TypeError("All keys must be strings.")
         return item.lower() in self.map.keys()
 
     def __eq__(self, other) -> bool:
         """We convert both to regular set, and compare their lower case values"""
         if not all([isinstance(i, str) for i in other]):
-            raise ValueError("All items must be strings!")
+            raise TypeError("All items must be strings!")
         a = set([s.lower() for s in list(self)])
         b = set([o.lower() for o in list(other)])
         return a.__eq__(b)

--- a/baseclasses/utils.py
+++ b/baseclasses/utils.py
@@ -1,5 +1,6 @@
 from collections.abc import MutableMapping, MutableSet
 
+
 class CaseInsensitiveDict(MutableMapping):
     """
     Python dictionary where the keys are case-insensitive.
@@ -16,8 +17,7 @@ class CaseInsensitiveDict(MutableMapping):
 
     def __init__(self, *args, **kwargs):
         self.data = dict(*args, **kwargs)
-        self._keys = list(self.data.keys())
-        self.map = {k.lower(): k for k in self._keys}
+        self.map = {k.lower(): k for k in self.data.keys()}
 
     def _getKey(self, key):
         """
@@ -43,8 +43,6 @@ class CaseInsensitiveDict(MutableMapping):
         existingKey = self._getKey(key)
         if existingKey:
             key = existingKey
-        else:
-            self._keys.append(key)
         self.data[key] = value
         self.map[key.lower()] = key
 
@@ -57,18 +55,19 @@ class CaseInsensitiveDict(MutableMapping):
         if existingKey:
             self.map.pop(existingKey.lower())
             self.data.pop(existingKey)
-            self._keys.remove(existingKey)
 
     def __iter__(self):
         return iter(self.data)
 
     def __len__(self):
-        return len(self._keys)
+        return len(self.data.keys())
 
     def __eq__(self, other):
         selfLower = {k.lower(): v for k, v in self.items()}
         otherLower = {k.lower(): v for k, v in other.items()}
         return selfLower.__eq__(otherLower)
+
+
 class CaseInsensitiveSet(MutableSet):
     """
     Python set where the elements are case-insensitive.
@@ -154,6 +153,7 @@ class CaseInsensitiveSet(MutableSet):
         lowerSelf = set([s.lower() for s in self])
         lowerOther = set([s.lower() for s in other])
         return lowerSelf.issubset(lowerOther)
+
 
 class Error(Exception):
     """

--- a/tests/test_CaseInsensitve.py
+++ b/tests/test_CaseInsensitve.py
@@ -16,8 +16,13 @@ value3 = 132
 class TestCaseInsensitiveDict(unittest.TestCase):
     def setUp(self):
         self.d = CaseInsensitiveDict({"OPtion1": value1})
-        self.d2 = CaseInsensitiveDict({"opTION1": value2, "optioN2": value2})
+        self.d2 = CaseInsensitiveDict(opTION1=value2, optioN2=value2)  # test different initialization
         self.d3 = {"regular dict": 1}
+
+    def test_empty_init(self):
+        d = CaseInsensitiveDict()
+        self.assertEqual(len(d), 0)
+        self.assertEqual(list(d.items()), [])
 
     def test_get(self):
         # test __getitem__
@@ -81,7 +86,6 @@ class TestCaseInsensitiveDict(unittest.TestCase):
         # check update preserves old capitalization
         self.assertEqual(set(self.d.keys()), {"OPtion1", "regular dict"})
 
-    @unittest.expectedFailure
     def test_update_regular_dict_with_dict(self):
         # update regular dict with this dict
         self.d3.update(self.d)
@@ -99,11 +103,29 @@ class TestCaseInsensitiveDict(unittest.TestCase):
         new_dict = pickle.loads(pickle.dumps(self.d))
         self.assertEqual(self.d, new_dict)
 
+    def test_items(self):
+        res = []
+        for k, v in self.d2.items():
+            res.append((k, v))
+        self.assertEqual(res, [("opTION1", value2), ("optioN2", value2)])
+
+    def test_iter(self):
+        res = []
+        for k in self.d2:
+            res.append(k)
+        self.assertEqual(res, ["opTION1", "optioN2"])
+
+
 class TestCaseInsensitiveSet(unittest.TestCase):
     def setUp(self):
         self.s = CaseInsensitiveSet({"Option1"})
         self.s2 = CaseInsensitiveSet({"OPTION1", "opTION2"})
         self.s3 = {"regular set"}
+
+    def test_empty_init(self):
+        s = CaseInsensitiveSet()
+        self.assertEqual(len(s), 0)
+        self.assertEqual(list(s), [])
 
     def test_add_contains(self):
         # test __contains__ and add()
@@ -177,6 +199,13 @@ class TestCaseInsensitiveSet(unittest.TestCase):
     def test_pickle(self):
         new_set = pickle.loads(pickle.dumps(self.s))
         self.assertEqual(self.s, new_set)
+
+    def test_iter(self):
+        res = set()
+        for k in self.s2:
+            res.add(k)
+        self.assertEqual(res, self.s2)
+
 
 class TestParallel(unittest.TestCase):
     N_PROCS = 2

--- a/tests/test_CaseInsensitve.py
+++ b/tests/test_CaseInsensitve.py
@@ -56,6 +56,8 @@ class TestCaseInsensitiveDict(unittest.TestCase):
         # check case insensitive contain
         self.assertIn("OPTION2", self.d)
         self.assertNotIn("INVALID", self.d)
+        with self.assertRaises(KeyError):
+            self.d["INVALID"]
 
     def test_del(self):
         # test __del__

--- a/tests/test_CaseInsensitve.py
+++ b/tests/test_CaseInsensitve.py
@@ -1,4 +1,5 @@
 import unittest
+import pickle
 from baseclasses.utils import CaseInsensitiveDict, CaseInsensitiveSet
 from parameterized import parameterized
 
@@ -80,6 +81,7 @@ class TestCaseInsensitiveDict(unittest.TestCase):
         # check update preserves old capitalization
         self.assertEqual(set(self.d.keys()), {"OPtion1", "regular dict"})
 
+    @unittest.expectedFailure
     def test_update_regular_dict_with_dict(self):
         # update regular dict with this dict
         self.d3.update(self.d)
@@ -93,6 +95,9 @@ class TestCaseInsensitiveDict(unittest.TestCase):
         d = CaseInsensitiveDict({"opTIon1": value1})
         self.assertEqual(d, self.d)
 
+    def test_pickle(self):
+        new_dict = pickle.loads(pickle.dumps(self.d))
+        self.assertEqual(self.d, new_dict)
 
 class TestCaseInsensitiveSet(unittest.TestCase):
     def setUp(self):
@@ -104,15 +109,15 @@ class TestCaseInsensitiveSet(unittest.TestCase):
         # test __contains__ and add()
         self.assertIn("OPTION1", self.s)
         # test original capitalization is preserved on initialization
-        self.assertEqual({"Option1"}, self.s._getKeys())
+        self.assertEqual({"Option1"}, self.s.data)
         self.s.add("OPTION2")
         self.assertIn("option2", self.s)
         # now add the same key again with different capitalization
         self.s.add("option2")
-        self.assertNotIn("option2", self.s._getKeys())
-        self.assertIn("OPTION2", self.s._getKeys())
+        self.assertNotIn("option2", self.s.data)
+        self.assertIn("OPTION2", self.s.data)
         # test original capitalization is preserved on new item
-        self.assertEqual({"Option1", "OPTION2"}, self.s._getKeys())
+        self.assertEqual({"Option1", "OPTION2"}, self.s.data)
 
     def test_len(self):
         self.assertEqual(len(self.s2), 2)
@@ -124,14 +129,14 @@ class TestCaseInsensitiveSet(unittest.TestCase):
         self.s.update(self.s2)
         self.assertTrue(isinstance(self.s, CaseInsensitiveSet))
         self.assertEqual(len(self.s), 2)
-        self.assertEqual(self.s._getKeys(), {"Option1", "opTION2"})
+        self.assertEqual(self.s.data, {"Option1", "opTION2"})
 
     def test_update_with_regular_set(self):
         # test regular set update
         self.s.update(self.s3)
         self.assertTrue(isinstance(self.s, CaseInsensitiveSet))
         self.assertIn("REGULAR SET", self.s)
-        self.assertEqual({"Option1", "regular set"}, self.s._getKeys())
+        self.assertEqual({"Option1", "regular set"}, self.s.data)
 
     def test_update_regular_set_with_set(self):
         self.s3.update(self.s)
@@ -169,6 +174,9 @@ class TestCaseInsensitiveSet(unittest.TestCase):
         self.s2.remove("opTION2")
         self.assertEqual(self.s, self.s2)
 
+    def test_pickle(self):
+        new_set = pickle.loads(pickle.dumps(self.s))
+        self.assertEqual(self.s, new_set)
 
 class TestParallel(unittest.TestCase):
     N_PROCS = 2

--- a/tests/test_CaseInsensitve.py
+++ b/tests/test_CaseInsensitve.py
@@ -121,6 +121,17 @@ class TestCaseInsensitiveDict(unittest.TestCase):
             res.append(k)
         self.assertEqual(res, ["opTION1", "optioN2"])
 
+    def test_keys(self):
+        k = list(self.d2.keys())
+        self.assertEqual(k, ["opTION1", "optioN2"])
+
+    def test_values(self):
+        v = list(self.d2.values())
+        self.assertEqual(v, [value2, value2])
+
+    def test_repr(self):
+        self.assertEqual(self.d2.__str__(), self.d2.data.__str__())
+
 
 class TestCaseInsensitiveSet(unittest.TestCase):
     def setUp(self):
@@ -214,6 +225,9 @@ class TestCaseInsensitiveSet(unittest.TestCase):
         for k in self.s2:
             res.add(k)
         self.assertEqual(res, self.s2)
+
+    def test_repr(self):
+        self.assertEqual(self.s2.__str__(), self.s2.data.__str__())
 
 
 class TestParallel(unittest.TestCase):

--- a/tests/test_CaseInsensitve.py
+++ b/tests/test_CaseInsensitve.py
@@ -24,6 +24,10 @@ class TestCaseInsensitiveDict(unittest.TestCase):
         self.assertEqual(len(d), 0)
         self.assertEqual(list(d.items()), [])
 
+    def test_invalid_init(self):
+        with self.assertRaises(ValueError):
+            CaseInsensitiveDict({1: 1})
+
     def test_get(self):
         # test __getitem__
         self.assertEqual(self.d["OPTION1"], value1)
@@ -127,6 +131,10 @@ class TestCaseInsensitiveSet(unittest.TestCase):
         self.assertEqual(len(s), 0)
         self.assertEqual(list(s), [])
 
+    def test_invalid_init(self):
+        with self.assertRaises(ValueError):
+            CaseInsensitiveSet({1, 2.5})
+
     def test_add_contains(self):
         # test __contains__ and add()
         self.assertIn("OPTION1", self.s)
@@ -147,7 +155,6 @@ class TestCaseInsensitiveSet(unittest.TestCase):
         self.assertEqual(len(self.s2), 1)
 
     def test_update(self):
-        # test update()
         self.s.update(self.s2)
         self.assertTrue(isinstance(self.s, CaseInsensitiveSet))
         self.assertEqual(len(self.s), 2)

--- a/tests/test_CaseInsensitve.py
+++ b/tests/test_CaseInsensitve.py
@@ -25,7 +25,7 @@ class TestCaseInsensitiveDict(unittest.TestCase):
         self.assertEqual(list(d.items()), [])
 
     def test_invalid_init(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             CaseInsensitiveDict({1: 1})
 
     def test_get(self):
@@ -145,7 +145,7 @@ class TestCaseInsensitiveSet(unittest.TestCase):
         self.assertEqual(list(s), [])
 
     def test_invalid_init(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             CaseInsensitiveSet({1, 2.5})
 
     def test_add_contains(self):


### PR DESCRIPTION
## Purpose
I recently discovered abstract base classes in Python, and they seem like the correct approach for implementing these containers, since it's very clear which methods need to be implemented and which you get for free via inheritance. See for example [this article](https://treyhunner.com/2019/04/why-you-shouldnt-inherit-from-list-and-dict-in-python/) for a relevant discussion. Overall I think this is a much better implementation than what we had before, i.e. directly inheriting `dict` and `set`. A few things to note:
- I added a few new tests
- I added type annotations
- I clarified in docstrings that the initial capitalization is _persistent_, meaning `update()` etc. with a different capitalization will not replace it. I think this is the behaviour we want in relation to options dictionaries.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
I added a few more tests.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
