### PR TITLE
Added `require_mpi` decorator for testing

### DIFF
--- a/baseclasses/decorators.py
+++ b/baseclasses/decorators.py
@@ -1,0 +1,26 @@
+import functools
+import unittest
+
+
+def require_mpi(func):
+    try:
+        from mpi4py import MPI  # noqa
+
+        # this is a wrapper on func
+        # but we inject the MPI option in the signature
+        def wrapper(*args, **kwargs):
+            func(*args, **kwargs)
+
+        return wrapper
+    except ImportError:
+        msg = "mpi4py is not installed."
+        if not isinstance(func, type):
+            # this wraps obj, which is the actual function
+            @functools.wraps(func)
+            def skip_wrapper(*args, **kwargs):
+                raise unittest.SkipTest(msg)
+
+            obj = skip_wrapper
+        obj.__unittest_skip__ = True
+        obj.__unittest_skip_why__ = msg
+        return obj

--- a/baseclasses/decorators.py
+++ b/baseclasses/decorators.py
@@ -1,6 +1,6 @@
 import functools
 import unittest
-import importlib
+from importlib.util import find_spec
 
 
 def require_mpi(func):
@@ -35,7 +35,7 @@ def base_require(func, module, message=None):
         If module is not found
     """
     # we check if the module can be found
-    module = importlib.find_loader(module)
+    module = find_spec(module)
     # if not found
     if module is None:
         if message is None:

--- a/tests/test_BaseRegTest.py
+++ b/tests/test_BaseRegTest.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 from baseclasses import BaseRegTest
 from baseclasses.BaseRegTest import getTol
+from baseclasses.decorators import require_mpi
 
 try:
     from mpi4py import MPI
@@ -118,7 +119,7 @@ class TestBaseRegTest(unittest.TestCase):
         handler = BaseRegTest(self.ref_file, train=False)
         self.regression_test_root(handler)
 
-    @unittest.skipIf(MPI is None, "mpi4py not imported")
+    @require_mpi
     def test_train_then_test_par(self):
         """
         Test for adding values in parallel, both in training and in testing
@@ -133,5 +134,5 @@ class TestBaseRegTest(unittest.TestCase):
             self.regression_test_par(handler)
 
     def tearDown(self):
-        if self.rank == 0:
+        if self.rank == 0 and hasattr(self, "ref_file"):
             os.remove(self.ref_file)

--- a/tests/test_BaseSolver.py
+++ b/tests/test_BaseSolver.py
@@ -1,11 +1,7 @@
-try:
-    from mpi4py import MPI
-except ImportError:
-    MPI = None
-
 import unittest
 from baseclasses import BaseSolver
 from baseclasses.utils import Error
+from baseclasses.decorators import require_mpi
 
 
 class SOLVER(BaseSolver):
@@ -143,8 +139,10 @@ class TestComm(unittest.TestCase):
 
     N_PROCS = 2
 
-    @unittest.skipIf(MPI is None, "mpi4py not imported")
+    @require_mpi
     def test_comm_with_mpi(self):
+        from mpi4py import MPI
+
         # initialize solver
         solver = SOLVER("testComm", comm=MPI.COMM_WORLD)
         self.assertFalse(solver.comm is None)

--- a/tests/test_CaseInsensitve.py
+++ b/tests/test_CaseInsensitve.py
@@ -1,11 +1,7 @@
 import unittest
 from baseclasses.utils import CaseInsensitiveDict, CaseInsensitiveSet
 from parameterized import parameterized
-
-try:
-    from mpi4py import MPI
-except ImportError:
-    MPI = None
+from baseclasses.decorators import require_mpi
 
 value1 = 123
 value2 = 321
@@ -174,8 +170,10 @@ class TestParallel(unittest.TestCase):
     N_PROCS = 2
 
     @parameterized.expand(["CaseInsensitiveDict", "CaseInsensitiveSet"])
-    @unittest.skipIf(MPI is None, "mpi4py not imported")
+    @require_mpi
     def test_bcast(self, class_type):
+        from mpi4py import MPI
+
         comm = MPI.COMM_WORLD
         d = {"OPtion1": 1}
         s = {"OPtion1"}


### PR DESCRIPTION
## Purpose
I added a decorator `require_mpi` which can be used to skip a test that has a dependency on MPI. I also made a general constructor which can be used to skip tests based on availability of any Python package, so this can be used downstream in MACH repos (e.g. ESP tests in pygeo).

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
I did test locally in an environment without `mpi4py` that the decorator works as expected.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
