### PR TITLE
Fix pprint for custom containers

### DIFF
--- a/baseclasses/utils.py
+++ b/baseclasses/utils.py
@@ -1,5 +1,6 @@
 from collections.abc import MutableMapping, MutableSet
 from typing import Any, Dict, Optional
+from pprint import pformat
 
 
 class CaseInsensitiveDict(MutableMapping):
@@ -93,7 +94,7 @@ class CaseInsensitiveDict(MutableMapping):
         return selfLower.__eq__(otherLower)
 
     def __repr__(self):
-        return str(self.data)
+        return pformat(self.data)
 
 
 class CaseInsensitiveSet(MutableSet):
@@ -202,7 +203,7 @@ class CaseInsensitiveSet(MutableSet):
         return lowerSelf.issubset(lowerOther)
 
     def __repr__(self):
-        return str(self.data)
+        return pformat(self.data)
 
 
 class Error(Exception):

--- a/tests/test_CaseInsensitve.py
+++ b/tests/test_CaseInsensitve.py
@@ -1,5 +1,6 @@
 import unittest
 import pickle
+from pprint import pformat
 from baseclasses.utils import CaseInsensitiveDict, CaseInsensitiveSet
 from parameterized import parameterized
 from baseclasses.decorators import require_mpi
@@ -128,6 +129,14 @@ class TestCaseInsensitiveDict(unittest.TestCase):
     def test_repr(self):
         self.assertEqual(self.d2.__str__(), self.d2.data.__str__())
 
+    def test_repr_pprint(self):
+        long_dict = {"b-longstring": 2, "a-longstring": 1, "c-longstring": 3, "e-longstring": 5, "d-longstring": 4}
+        string_format = pformat(CaseInsensitiveDict(long_dict))
+        string_expected = (
+            "{'a-longstring': 1,\n 'b-longstring': 2,\n 'c-longstring': 3,\n 'd-longstring': 4,\n 'e-longstring': 5}"
+        )
+        self.assertEqual(string_format, string_expected)
+
 
 class TestCaseInsensitiveSet(unittest.TestCase):
     def setUp(self):
@@ -224,6 +233,14 @@ class TestCaseInsensitiveSet(unittest.TestCase):
 
     def test_repr(self):
         self.assertEqual(self.s2.__str__(), self.s2.data.__str__())
+
+    def test_repr_pprint(self):
+        long_set = {"a-longstring", "b-longstring", "c-longstring", "d-longstring", "e-longstring", "f-longstring"}
+        string_format = pformat(CaseInsensitiveSet(long_set))
+        string_expected = (
+            "{'a-longstring',\n 'b-longstring',\n 'c-longstring',\n 'd-longstring',\n 'e-longstring',\n 'f-longstring'}"
+        )
+        self.assertEqual(string_format, string_expected)
 
 
 class TestParallel(unittest.TestCase):


### PR DESCRIPTION
## Purpose
Closes #53. Turns out this was super easy, and I just had to make `repr` use the `pformat` function, which is the function that does the `pprint` formatting without printing anything out. I also added tests to check that the output strings are as expected.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
I added two tests.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
