### PR TITLE
Fixed module name printed as None in decorator message

### DIFF
--- a/baseclasses/decorators.py
+++ b/baseclasses/decorators.py
@@ -7,7 +7,7 @@ def require_mpi(func):
     return base_require(func, "mpi4py")
 
 
-def base_require(func, module, message=None):
+def base_require(func, moduleName, message=None):
     """
     This is a generic function that can be used to generate decorators
     that test an import, and skips a test based on whether the library
@@ -18,7 +18,7 @@ def base_require(func, module, message=None):
     func : callable
         The function that the decorator is applied to. This is the required argument for a decorator and
         is passed in automatically
-    module : str
+    moduleName : str
         The module to test import for
     message : str
         The message for skipTest. The default is "<module> is not installed."
@@ -35,11 +35,11 @@ def base_require(func, module, message=None):
         If module is not found
     """
     # we check if the module can be found
-    module = find_spec(module)
+    module = find_spec(moduleName)
     # if not found
     if module is None:
         if message is None:
-            message = f"{module} is not installed."
+            message = f"{moduleName} is not installed."
         # this is the alternative function which gets executed
         # by the decorator, which just raises skiptest
 


### PR DESCRIPTION
## Purpose
The skip test decorator prints a message if a required module is not found. There was a small bug where the message would simply say "None is not installed" since I overwrite the name of the module. This has now been fixed.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Create an environment without `mpi4py` and run the tests for `baseclasses` with `testflo . -v`. You should see messages such as `mpi4py is not installed" instead of `None is not installed".

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
