### PR TITLE
added optional flush option to custom pp function

### DIFF
--- a/baseclasses/solvers/BaseSolver.py
+++ b/baseclasses/solvers/BaseSolver.py
@@ -224,7 +224,7 @@ class BaseSolver:
         modifiedOptions = self.getModifiedOptions()
         self.pp(modifiedOptions)
 
-    def pp(self, obj):
+    def pp(self, obj, flush=False):
         """
         This method prints ``obj`` (via pprint) on the root proc of ``self.comm`` if it exists.
         Otherwise it will just print ``obj``.
@@ -236,6 +236,6 @@ class BaseSolver:
         """
         if (self.comm is not None and self.comm.rank == 0) or self.comm is None:
             if isinstance(obj, str):
-                print(obj)
+                print(obj, flush=flush)
             else:
                 pprint(obj)


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
The custom `pp` (pretty-print) function in BaseSolver now has an optional `flush` argument that is passed to the `print` function (for strings only).
This is helpful to address some of the issues we see when redirecting the `stdout` to an output file, and in general offers more use flexibility.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
