### PR TITLE
Redirect fix

### DIFF
--- a/baseclasses/utils/fileIO.py
+++ b/baseclasses/utils/fileIO.py
@@ -262,5 +262,3 @@ def redirectingIO(f_out, f_err=None):
     # reopen the standard streams with original file descriptors
     sys.stdout = io.TextIOWrapper(os.fdopen(orig_out, "wb"))
     sys.stderr = io.TextIOWrapper(os.fdopen(orig_err, "wb"))
-
-

--- a/baseclasses/utils/fileIO.py
+++ b/baseclasses/utils/fileIO.py
@@ -255,6 +255,12 @@ def redirectingIO(f_out, f_err=None):
     os.dup2(saved_stdout_fd, orig_out)
     os.dup2(saved_stderr_fd, orig_err)
 
+    # close copies
+    os.close(saved_stdout_fd)
+    os.close(saved_stderr_fd)
+
     # reopen the standard streams with original file descriptors
     sys.stdout = io.TextIOWrapper(os.fdopen(orig_out, "wb"))
     sys.stderr = io.TextIOWrapper(os.fdopen(orig_err, "wb"))
+
+

--- a/tests/test_fileIO.py
+++ b/tests/test_fileIO.py
@@ -5,13 +5,8 @@ from unittest.mock import patch, MagicMock
 from parameterized import parameterized
 from baseclasses.testing.decorators import require_mpi
 from baseclasses.testing.assertions import assert_equal
-from baseclasses.utils import (
-    readPickle,
-    writePickle,
-    readJSON,
-    writeJSON,
-    redirectingIO,
-)
+from baseclasses.utils import readPickle, writePickle, readJSON, writeJSON, redirectingIO
+
 import numpy as np
 
 try:

--- a/tests/test_fileIO.py
+++ b/tests/test_fileIO.py
@@ -6,7 +6,11 @@ from parameterized import parameterized
 from baseclasses.testing.decorators import require_mpi
 from baseclasses.testing.assertions import assert_equal
 from baseclasses.utils import (
-    readPickle, writePickle, readJSON, writeJSON, redirectingIO
+    readPickle,
+    writePickle,
+    readJSON,
+    writeJSON,
+    redirectingIO,
 )
 import numpy as np
 
@@ -57,17 +61,17 @@ class TestFileIO(unittest.TestCase):
         newObj = readJSON(self.fileName, comm=self.comm)
         assert_equal(obj, newObj)
 
-    @patch('sys.stdout', new_callable=io.StringIO)
-    @patch('sys.stderr', new_callable=io.StringIO)
+    @patch("sys.stdout", new_callable=io.StringIO)
+    @patch("sys.stderr", new_callable=io.StringIO)
     def test_redirectingIO(self, mock_stdout, mock_stderr):
         mock_stdout.fileno = MagicMock(return_value=0)
         mock_stderr.fileno = MagicMock(return_value=1)
 
-        self.fileName = 'test_redirect.out'
+        self.fileName = "test_redirect.out"
 
         for i in range(2048):
-            with redirectingIO(open(self.fileName, 'a')):
-                print(f'test_{i}')
+            with redirectingIO(open(self.fileName, "a")):
+                print(f"test_{i}")
 
         # This is only here so the test is considered ok if
         # it finishes without error

--- a/tests/test_fileIO.py
+++ b/tests/test_fileIO.py
@@ -75,7 +75,7 @@ class TestFileIO(unittest.TestCase):
 
         # This is only here so the test is considered ok if
         # it finishes without error
-        self.assert_(True)
+        self.assertTrue(True)
 
     def tearDown(self):
         if self.comm.rank == 0:

--- a/tests/test_fileIO.py
+++ b/tests/test_fileIO.py
@@ -1,9 +1,11 @@
 import unittest
 import os
+import io
+from unittest.mock import patch, MagicMock
 from parameterized import parameterized
 from baseclasses.testing.decorators import require_mpi
 from baseclasses.testing.assertions import assert_equal
-from baseclasses.utils import readPickle, writePickle, readJSON, writeJSON
+from baseclasses.utils import readPickle, writePickle, readJSON, writeJSON, redirectingIO
 import numpy as np
 
 try:
@@ -52,6 +54,22 @@ class TestFileIO(unittest.TestCase):
         writeJSON(self.fileName, obj, comm=self.comm)
         newObj = readJSON(self.fileName, comm=self.comm)
         assert_equal(obj, newObj)
+
+    @patch('sys.stdout', new_callable=io.StringIO)
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_redirectingIO(self, mock_stdout, mock_stderr):
+        mock_stdout.fileno = MagicMock(return_value=0)
+        mock_stderr.fileno = MagicMock(return_value=1)
+
+        self.fileName = 'test_redirect.out'
+
+        for i in range(2048):
+            with redirectingIO(open(self.fileName, 'a')):
+                print(f'test_{i}')
+
+        # This is only here so the test is considered ok if
+        # it finishes without error
+        self.assert_(True)
 
     def tearDown(self):
         if self.comm.rank == 0:

--- a/tests/test_fileIO.py
+++ b/tests/test_fileIO.py
@@ -5,7 +5,9 @@ from unittest.mock import patch, MagicMock
 from parameterized import parameterized
 from baseclasses.testing.decorators import require_mpi
 from baseclasses.testing.assertions import assert_equal
-from baseclasses.utils import readPickle, writePickle, readJSON, writeJSON, redirectingIO
+from baseclasses.utils import (
+    readPickle, writePickle, readJSON, writeJSON, redirectingIO
+)
 import numpy as np
 
 try:


### PR DESCRIPTION
## Purpose
This fixes a bug where the whole script would crash because to many file handles were opened:
```
   ".../baseclasses/utils/fileIO.py", line 236, in redirectingIO
OSError: [Errno 24] Too many open files
```

## Expected time until merged
~~Depends on your testing-requirements (see below)~~. I would be happy if this could be merged asap.

## Type of change


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
~~I tried implementing a test. But it is not that easy because it messes with the stdout and stderr. I personally understand the whole testing part to little to implement this properly.~~

I managed to implement a test that fails before the fix, but succeeds after it. 

But one can test it manually with this:
```
from mpi4py import MPI
from baseclasses.utils import redirectingIO

for i in range(2048):
    with redirectingIO(open('test.out', 'a')):
        print(f'test_{i}')

print('finished')
```

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
