### PR TITLE
Fix read functions when file does not exist

### DIFF
--- a/baseclasses/utils/fileIO.py
+++ b/baseclasses/utils/fileIO.py
@@ -102,6 +102,9 @@ def readJSON(fname, comm=None):
             return np.array(data, dct["dtype"]).reshape(dct["shape"])
         return dct
 
+    if not os.path.isfile(fname):
+        raise FileNotFoundError(f"The JSON file {fname} cannot be found.")
+
     data = None
     if (comm is None) or (comm is not None and comm.rank == 0):
         with open(fname, "r") as json_file:
@@ -128,6 +131,9 @@ def readPickle(fname, comm=None):
     -------
     obj : The object stored in the pickle file
     """
+    if not os.path.isfile(fname):
+        raise FileNotFoundError(f"The pickle file {fname} cannot be found.")
+
     obj = None
     if (comm is None) or (comm is not None and comm.rank == 0):
         try:


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
If the file does not exist, the functions `readPickle` and `readJSON` hangs indefinitely when called on more than one processors, because only the root proc is used for read/write.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
1 week.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
I updated existing tests to also run in parallel. I am not sure why I needed to add that one `comm.barrier()`, since a barrier should be present in the read/write routines, but without it the test fails.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
