### PR TITLE
Adding a simple parser to parse string format

### DIFF
--- a/baseclasses/utils/__init__.py
+++ b/baseclasses/utils/__init__.py
@@ -1,6 +1,6 @@
 from .containers import CaseInsensitiveSet, CaseInsensitiveDict
 from .error import Error
-from .utils import getPy3SafeString, pp
+from .utils import getPy3SafeString, pp, ParseStringFormat
 from .fileIO import writeJSON, readJSON, writePickle, readPickle, redirectIO, redirectingIO
 
 __all__ = [
@@ -15,4 +15,5 @@ __all__ = [
     "readPickle",
     "redirectIO",
     "redirectingIO",
+    "ParseStringFormat",
 ]

--- a/baseclasses/utils/utils.py
+++ b/baseclasses/utils/utils.py
@@ -1,6 +1,7 @@
 """
 Helper methods for supporting python3 and python2 at the same time
 """
+import re
 import sys
 from pprint import pformat
 
@@ -41,3 +42,82 @@ def pp(obj, comm=None, flush=True):
             # we use pformat to get the string and then call print manually, that way we can flush if we need to
             pprint_str = pformat(obj)
             print(pprint_str, flush=flush)
+
+
+class ParseStringFormat(object):
+    def __init__(self, fmt):
+        """
+        Parses the following string format:
+
+            [align][sign][width][grouping_option][.precision][type]
+
+        Note that ``fmt`` must be a valid format string and it should verified before using the parse.
+
+        Parameters
+        ----------
+        fmt : str
+            String format string, e.g., ``fmt = "{:^10}"``
+        """
+
+        # Initialize
+        self._align = None
+        self._sign = None
+        self._zero = None
+        self._width = None
+        self._precision = None
+        self._grouping_option = None
+        self._ftype = None
+
+        # Only get the content between the first {} and get rid of :
+        fmt = fmt[fmt.find("{") + 1 : fmt.find("}")][1:]
+
+        # Check for align characters. There can only be one for a valid string.
+        align = re.search("[<>=^]", fmt)
+        if align:
+            self._align = align[0]
+
+        # Check for sign characters. There can only be one for a valid string.
+        sign = re.search("[+ -]", fmt)
+        if sign:
+            self._sign = sign[0]
+
+        # Get width and precision
+        for i, item in enumerate(re.findall("[0-9]+", fmt)):
+            if i == 0:
+                self._width = int(item)
+            if i == 1:
+                self._precision = int(item)
+
+        # Check for grouping options
+        gOption = re.search("[_,]", fmt)
+        if gOption:
+            self._grouping_option = gOption[0]
+
+        # Get the formatting type
+        ftype = re.search("[bcdeEfFgGnosxX%]", fmt)
+        if ftype:
+            self._ftype = ftype[0]
+
+    @property
+    def align(self):
+        return self._align
+
+    @property
+    def sign(self):
+        return self._sign
+
+    @property
+    def width(self):
+        return self._width
+
+    @property
+    def precision(self):
+        return self._precision
+
+    @property
+    def grouping_option(self):
+        return self._grouping_option
+
+    @property
+    def ftype(self):
+        return self._ftype

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,99 @@
+# ==============================================================================
+# Standard Python modules
+# ==============================================================================
+import unittest
+
+# ==============================================================================
+# External Python modules
+# ==============================================================================
+from parameterized import parameterized_class
+
+# ==============================================================================
+# Extension modules
+# ==============================================================================
+from baseclasses.utils import ParseStringFormat
+
+
+@parameterized_class(
+    [
+        {
+            "fmt": "{: 17.11e}",
+            "true_align": None,
+            "true_sign": " ",
+            "true_width": 17,
+            "true_precision": 11,
+            "true_grouping_option": None,
+            "true_type": "e",
+        },
+        {
+            "fmt": "{:9.3e}",
+            "true_align": None,
+            "true_sign": None,
+            "true_width": 9,
+            "true_precision": 3,
+            "true_grouping_option": None,
+            "true_type": "e",
+        },
+        {
+            "fmt": "{:< 5d}",
+            "true_align": "<",
+            "true_sign": " ",
+            "true_width": 5,
+            "true_precision": None,
+            "true_grouping_option": None,
+            "true_type": "d",
+        },
+        {
+            "fmt": "{:^10}",
+            "true_align": "^",
+            "true_sign": None,
+            "true_width": 10,
+            "true_precision": None,
+            "true_grouping_option": None,
+            "true_type": None,
+        },
+        {
+            "fmt": "{:> 15,}",
+            "true_align": ">",
+            "true_sign": " ",
+            "true_width": 15,
+            "true_precision": None,
+            "true_grouping_option": ",",
+            "true_type": None,
+        },
+        {
+            "fmt": "{:> 15,} some other bracket {:< 9.2e}",
+            "true_align": ">",
+            "true_sign": " ",
+            "true_width": 15,
+            "true_precision": None,
+            "true_grouping_option": ",",
+            "true_type": None,
+        },
+    ]
+)
+class TestUtilsParseStringFormat(unittest.TestCase):
+    def setUp(self):
+        self.pf = ParseStringFormat(self.fmt)
+
+    def test_align_property(self):
+        self.assertEqual(self.pf.align, self.true_align)
+
+    def test_sign_property(self):
+        self.assertEqual(self.pf.sign, self.true_sign)
+
+    def test_width_property(self):
+        self.assertEqual(self.pf.width, self.true_width)
+
+    def test_precision_property(self):
+        self.assertEqual(self.pf.precision, self.true_precision)
+
+    def test_grouping_option_property(self):
+        self.assertEqual(self.pf.grouping_option, self.true_grouping_option)
+
+    def test_ftype_property(self):
+        self.assertEqual(self.pf.ftype, self.true_type)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose
This PR adds a very simple parser to parse string formats. This parser can be used to extract information for different str formats, such as width and sign, for printing to stdout. 

## Expected time until merged
No rush

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
