### PR TITLE
add `getIter` method to SolverHistory

### DIFF
--- a/baseclasses/utils/solverHistory.py
+++ b/baseclasses/utils/solverHistory.py
@@ -508,6 +508,16 @@ class SolverHistory(object):
         """
         return list(self._variables.keys())
 
+    def getIter(self) -> int:
+        """Get the current number of iterations recorded
+
+        Returns
+        -------
+        int
+            Number of iterations recorded
+        """
+        return copy.copy(self._iter)
+
     @property
     def _variablesToPrint(self) -> List[HistoryVariable]:
         """Get the variables to print

--- a/tests/test_SolverHistory.py
+++ b/tests/test_SolverHistory.py
@@ -108,6 +108,10 @@ class TestSolverHistoryWriting(unittest.TestCase):
             }
             self.solverHistory.write(iterData)
 
+    def test_getIter(self) -> None:
+        """Test that the getIter method returns the correct number of iterations"""
+        self.assertEqual(self.solverHistory.getIter(), self.numIters)
+
     def test_dataListLength(self) -> None:
         """Check that the data list has the correct length"""
         for var in self.solverHistory.getData().values():


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
Adds a method to get the iteration count from the solver history. I came across the need to do this in my nonlinear TACS solver (https://github.com/mdolab/pytacs/pull/51)

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->

5 minutes

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
