### PR TITLE
Custom ptsets

### DIFF
--- a/baseclasses/solvers/pyAero_solver.py
+++ b/baseclasses/solvers/pyAero_solver.py
@@ -80,7 +80,7 @@ class AeroSolver(BaseSolver):
         pts = self.getSurfaceCoordinates(self.meshFamilyGroup)
         self.mesh.setSurfaceDefinition(pts, conn, faceSizes)
 
-    def setDVGeo(self, DVGeo, pointSetKwargs={}, customPointSetFamilies=None):
+    def setDVGeo(self, DVGeo, pointSetKwargs=None, customPointSetFamilies=None):
         """
         Set the DVGeometry object that will manipulate 'geometry' in
         this object. Note that <SOLVER> does not **strictly** need a
@@ -98,8 +98,12 @@ class AeroSolver(BaseSolver):
             These arguments are used for all point sets added by this solver.
 
         customPointSetFamilies : dict of dicts
-            Keyword arguments to be passed to the DVGeo addPointSet call for each surface family,
-            specified by the keys. The surface families need to be all part of the designSurfaceFamily.
+            This argument is used to split up the surface points added to the DVGeo by the solver into potentially
+            multiple subsets. The keys of the dictionary will be used to determine what families should be
+            added to the dvgeo object as separate point sets. The values of each key is another dictionary, which can be empty.
+            If desired, the inner dictionaries can contain custom kwargs for the addPointSet call for each surface family,
+            specified by the keys of the top level dictionary.
+            The surface families need to be all part of the designSurfaceFamily.
             Useful for DVGeometryMulti, specifying FFD projection tolerances, etc.
             If this is provided together with pointSetKwargs, the regular pointSetKwargs
             will be appended to each component's dictionary. If the same argument
@@ -115,10 +119,16 @@ class AeroSolver(BaseSolver):
         self.DVGeo = DVGeo
 
         # save the common kwargs dict. default is empty
-        self.pointSetKwargs = pointSetKwargs
+        if pointSetKwargs is None:
+            self.pointSetKwargs = {}
+        else:
+            self.pointSetKwargs = pointSetKwargs
 
         # save if we have customPointSetFamilies
-        self.customPointSetFamilies = customPointSetFamilies
+        if customPointSetFamilies is None:
+            self.customPointSetFamilies = None
+        else:
+            self.customPointSetFamilies = customPointSetFamilies
 
     def getTriangulatedMeshSurface(self, groupName=None, **kwargs):
         """

--- a/baseclasses/solvers/pyAero_solver.py
+++ b/baseclasses/solvers/pyAero_solver.py
@@ -54,8 +54,9 @@ class AeroSolver(BaseSolver):
         self.families = CaseInsensitiveDict()
         self._updateGeomInfo = False
 
-        # Initialize kwargs for addPointSet
+        # Initialize kwargs for addPointSet and customPointSetFamilies
         self.pointSetKwargs = None
+        self.customPointSetFamilies = None
 
     def setMesh(self, mesh):
         """

--- a/baseclasses/solvers/pyAero_solver.py
+++ b/baseclasses/solvers/pyAero_solver.py
@@ -95,13 +95,16 @@ class AeroSolver(BaseSolver):
         pointSetKwargs : dict
             Keyword arguments to be passed to the DVGeo addPointSet call.
             Useful for DVGeometryMulti, specifying FFD projection tolerances, etc.
+            These arguments are used for all point sets added by this solver.
 
-        customPointSetKwargs : dict of dicts
+        customPointSetFamilies : dict of dicts
             Keyword arguments to be passed to the DVGeo addPointSet call for each surface family,
             specified by the keys. The surface families need to be all part of the designSurfaceFamily.
             Useful for DVGeometryMulti, specifying FFD projection tolerances, etc.
             If this is provided together with pointSetKwargs, the regular pointSetKwargs
-            will be appended to each component's dictionary.
+            will be appended to each component's dictionary. If the same argument
+            is also provided in pointSetKwargs, the value specified in customPointSetFamilies
+            will be used.
 
         Examples
         --------

--- a/baseclasses/solvers/pyAero_solver.py
+++ b/baseclasses/solvers/pyAero_solver.py
@@ -124,11 +124,8 @@ class AeroSolver(BaseSolver):
         else:
             self.pointSetKwargs = pointSetKwargs
 
-        # save if we have customPointSetFamilies
-        if customPointSetFamilies is None:
-            self.customPointSetFamilies = None
-        else:
-            self.customPointSetFamilies = customPointSetFamilies
+        # save if we have customPointSetFamilies. this default is not mutable so we can just set it as is.
+        self.customPointSetFamilies = customPointSetFamilies
 
     def getTriangulatedMeshSurface(self, groupName=None, **kwargs):
         """

--- a/baseclasses/solvers/pyAero_solver.py
+++ b/baseclasses/solvers/pyAero_solver.py
@@ -80,7 +80,7 @@ class AeroSolver(BaseSolver):
         pts = self.getSurfaceCoordinates(self.meshFamilyGroup)
         self.mesh.setSurfaceDefinition(pts, conn, faceSizes)
 
-    def setDVGeo(self, DVGeo, pointSetKwargs=None):
+    def setDVGeo(self, DVGeo, pointSetKwargs={}, customPointSetFamilies=None):
         """
         Set the DVGeometry object that will manipulate 'geometry' in
         this object. Note that <SOLVER> does not **strictly** need a
@@ -96,6 +96,13 @@ class AeroSolver(BaseSolver):
             Keyword arguments to be passed to the DVGeo addPointSet call.
             Useful for DVGeometryMulti, specifying FFD projection tolerances, etc.
 
+        customPointSetKwargs : dict of dicts
+            Keyword arguments to be passed to the DVGeo addPointSet call for each surface family,
+            specified by the keys. The surface families need to be all part of the designSurfaceFamily.
+            Useful for DVGeometryMulti, specifying FFD projection tolerances, etc.
+            If this is provided together with pointSetKwargs, the regular pointSetKwargs
+            will be appended to each component's dictionary.
+
         Examples
         --------
         >>> CFDsolver = <SOLVER>(comm=comm, options=CFDoptions)
@@ -104,10 +111,11 @@ class AeroSolver(BaseSolver):
 
         self.DVGeo = DVGeo
 
-        if pointSetKwargs is None:
-            self.pointSetKwargs = {}
-        else:
-            self.pointSetKwargs = pointSetKwargs
+        # save the common kwargs dict. default is empty
+        self.pointSetKwargs = pointSetKwargs
+
+        # save if we have customPointSetFamilies
+        self.customPointSetFamilies = customPointSetFamilies
 
     def getTriangulatedMeshSurface(self, groupName=None, **kwargs):
         """


### PR DESCRIPTION
## Purpose

This PR adds capability to set custom pointsets when adding DVGeo to the aero solver. The custom pointsets are provided in a dict where keys are the corresponding family names in the solver and values are the custom kwargs passed with those pointsets. See the relevant ADflow PR: https://github.com/mdolab/adflow/pull/299

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
