### PR TITLE
Fix some docstrings

### DIFF
--- a/baseclasses/problems/pyAero_problem.py
+++ b/baseclasses/problems/pyAero_problem.py
@@ -5,15 +5,17 @@ pyAero_problem
 # =============================================================================
 # Imports
 # =============================================================================
-import numpy as np
 import warnings
-from .ICAOAtmosphere import ICAOAtmosphere
-from .FluidProperties import FluidProperties
+
+import numpy as np
+
 from ..utils import CaseInsensitiveDict, Error, SolverHistory
+from .FluidProperties import FluidProperties
+from .ICAOAtmosphere import ICAOAtmosphere
 
 
 class AeroProblem(FluidProperties):
-    """
+    r"""
     The main purpose of this class is to represent all relevant
     information for a single aerodynamic analysis. This will
     include the thermodynamic parameters defining the flow
@@ -27,7 +29,7 @@ class AeroProblem(FluidProperties):
         This is the preferred method for specifying flight conditions.
         This is suitable for all aerodynamic analysis codes, including aerostructural analysis.
         The 1976 standard atmosphere is used to compute :math:`P` and :math:`T`.
-        We then compute :math:`\\rho = P / RT`.
+        We then compute :math:`\rho = P / RT`.
         The remaining quantities are computed with :meth:`baseclasses.AeroProblem._updateFromM`.
         The resulting Reynolds number depends on the scale of the mesh.
 
@@ -41,32 +43,32 @@ class AeroProblem(FluidProperties):
 
     'mach' + 'T' + 'P':
         Any arbitrary temperature and pressure.
-        The inputs are first used to compute :math:`\\rho = P / RT`.
+        The inputs are first used to compute :math:`\rho = P / RT`.
         The remaining quantities are then computed with :meth:`baseclasses.AeroProblem._updateFromM`.
 
     'mach' + 'T' + 'rho':
         Any arbitrary temperature and density.
-        The inputs are first used to compute :math:`P = \\rho RT`.
+        The inputs are first used to compute :math:`P = \rho RT`.
         The remaining quantities are then computed with :meth:`baseclasses.AeroProblem._updateFromM`.
 
     'mach' + 'P' + 'rho':
         Any arbitrary density and pressure.
-        The inputs are first used to compute :math:`T = P / \\rho R`.
+        The inputs are first used to compute :math:`T = P / \rho R`.
         The remaining quantities are then computed with :meth:`baseclasses.AeroProblem._updateFromM`.
 
     'V' + 'rho' + 'T'
         Generally for low-speed specifications.
-        The inputs are first used to compute :math:`P = \\rho RT`.
+        The inputs are first used to compute :math:`P = \rho RT`.
         The remaining quantities are then computed with :meth:`baseclasses.AeroProblem._updateFromV`.
 
     'V' + 'rho' + 'P'
         Generally for low-speed specifications.
-        The inputs are first used to compute :math:`T = P / \\rho R`.
+        The inputs are first used to compute :math:`T = P / \rho R`.
         The remaining quantities are then computed with :meth:`baseclasses.AeroProblem._updateFromV`.
 
     'V' + 'T' + 'P'
         Generally for low-speed specifications.
-        The inputs are first used to compute :math:`\\rho = P / RT`.
+        The inputs are first used to compute :math:`\rho = P / RT`.
         The remaining quantities are then computed with :meth:`baseclasses.AeroProblem._updateFromV`.
 
     The combinations listed above are the **only** valid combinations
@@ -78,7 +80,7 @@ class AeroProblem(FluidProperties):
     set the 'P' (pressure) variable.
 
     For our compressible RANS solver, ADflow, the inputs from ``AeroProblem`` are the dimensional freestream values
-    :math:`M`, :math:`P`, :math:`T`, :math:`\\gamma`, :math:`\\rho`, :math:`R_{\\text{gas}}`,
+    :math:`M`, :math:`P`, :math:`T`, :math:`\gamma`, :math:`\rho`, :math:`R_{\text{gas}}`,
     Sutherland's law constants :math:`S`, :math:`T_{ref}`, :math:`\mu_{ref}`, and the Prandtl number :math:`Pr`.
     The non-dimensionalized inputs used in the actual ADflow CFD computations are derived from these inherited inputs.
 
@@ -919,15 +921,15 @@ R=100, muSuthDim=1.22e-3, TSuthDim=288.15)
     #         self.__dict__['rho'] = self.re*self.mu/self.V
 
     def _updateFromRe(self):
-        """
+        r"""
         Update the full set of states from Re, T, and either V or M with the following steps:
 
-        #. :math:`a = \sqrt{\\gamma RT}`
-        #. Compute :math:`\\mu(T)` from Sutherland's law.
+        #. :math:`a = \sqrt{\gamma RT}`
+        #. Compute :math:`\mu(T)` from Sutherland's law.
         #. :math:`V = M a` or :math:`M = V / a`
-        #. :math:`\\rho = \\frac{Re \\mu}{V L}`
-        #. :math:`P = \\rho R T`
-        #. :math:`q = 0.5 \\rho V^2`
+        #. :math:`\rho = \frac{Re \mu}{V L}`
+        #. :math:`P = \rho R T`
+        #. :math:`q = 0.5 \rho V^2`
 
         """
         # Calculate the speed of sound
@@ -955,15 +957,15 @@ R=100, muSuthDim=1.22e-3, TSuthDim=288.15)
         self.q = 0.5 * self.rho * self.V**2
 
     def _updateFromM(self):
-        """
+        r"""
         Update the full set of states from M, T, rho with the following steps:
 
-        #. :math:`a = \sqrt{\\gamma RT}`
-        #. Compute :math:`\\mu(T)` from Sutherland's law.
+        #. :math:`a = \sqrt{\gamma RT}`
+        #. Compute :math:`\mu(T)` from Sutherland's law.
         #. :math:`V = M a`
-        #. :math:`Re/L = \\rho V / \\mu`
-        #. :math:`\\nu = \\mu / \\rho`
-        #. :math:`q = 0.5 \\rho V^2`
+        #. :math:`Re/L = \rho V / \mu`
+        #. :math:`\nu = \mu / \rho`
+        #. :math:`q = 0.5 \rho V^2`
 
         """
         # Calculate the speed of sound
@@ -985,15 +987,15 @@ R=100, muSuthDim=1.22e-3, TSuthDim=288.15)
         self.q = 0.5 * self.rho * self.V**2
 
     def _updateFromV(self):
-        """
+        r"""
         Update the full set of states from V, T, rho with the following steps:
 
-        #. :math:`a = \sqrt{\\gamma RT}`
-        #. Compute :math:`\\mu(T)` from Sutherland's law.
-        #. :math:`\\nu = \\mu / \\rho`
-        #. :math:`q = 0.5 \\rho V^2`
+        #. :math:`a = \sqrt{\gamma RT}`
+        #. Compute :math:`\mu(T)` from Sutherland's law.
+        #. :math:`\nu = \mu / \rho`
+        #. :math:`q = 0.5 \rho V^2`
         #. :math:`M = V / a`
-        #. :math:`Re/L = \\rho V / \\mu`
+        #. :math:`Re/L = \rho V / \mu`
 
         """
         # Calculate the speed of sound

--- a/baseclasses/problems/pyFieldPerformance_problem.py
+++ b/baseclasses/problems/pyFieldPerformance_problem.py
@@ -6,13 +6,14 @@ pyFieldPerformance_problem
 # Imports
 # =============================================================================
 import warnings
-from .ICAOAtmosphere import ICAOAtmosphere
-from .FluidProperties import FluidProperties
+
 from ..utils import CaseInsensitiveDict, Error
+from .FluidProperties import FluidProperties
+from .ICAOAtmosphere import ICAOAtmosphere
 
 
 class FieldPerformanceProblem:
-    """
+    r"""
     The main purpose of this class is to represent all relevant
     information for a single field performance analysis. This includes
     an internal instance of the atmospheric calculation for computing
@@ -55,7 +56,7 @@ class FieldPerformanceProblem:
     span : float
         Total wingspan
 
-    \*\* Note \*\* Thrust and weight should be specified in terms of force.
+    ** Note ** Thrust and weight should be specified in terms of force.
 
     T_VA : float
         Idle thrust during approach. <force>
@@ -76,7 +77,7 @@ class FieldPerformanceProblem:
     TOW : float
         Takeoff gross weight. <force>
 
-    \*\* Note \*\* TSFC should be specified in terms of mass / time / force.
+    ** Note ** TSFC should be specified in terms of mass / time / force.
 
     TSFC_VA : float
         Thrust-specific fuel consumption with engine in idle during approach.

--- a/baseclasses/problems/pyLG_problem.py
+++ b/baseclasses/problems/pyLG_problem.py
@@ -108,9 +108,6 @@ class LGProblem:
         g_load = (self.V_vert**2 + (2 * self.g * (1 - self.loadFrac) * (self.tireDef + self.shockDef))) / (
             2.0 * self.g * (self.tireEff * self.tireDef + self.shockEff * self.shockDef)
         )
-        # print('gload',self.V_vert**2,(2*self.g*(1-self.loadFrac)*(self.tireDef+self.shockDef)),2.0 , self.g,self.tireEff * self.tireDef,self.shockEff * self.shockDef,self.V_vert**2 /(2.0 * self.g ),  (self.tireEff * self.tireDef + self.shockEff * self.shockDef))
-        # f_dyn =  self.aircraftMass * self.V_vert**2 /\
-        #          (4.0 * (self.tireEff * self.tireDef + self.shockEff * self.shockDef))
 
         f_dyn = (1.0 / self.nMainGear) * g_load * self.aircraftMass * self.g
 

--- a/baseclasses/testing/pyRegTest.py
+++ b/baseclasses/testing/pyRegTest.py
@@ -182,7 +182,7 @@ class BaseRegTest:
                 self._add_values(name, values, **kwargs)
 
     def root_add_dict(self, name, d, **kwargs):
-        """
+        r"""
         Only write from the root proc
 
         Parameters
@@ -200,7 +200,7 @@ class BaseRegTest:
 
     # Add values from all processors
     def par_add_val(self, name, values, **kwargs):
-        """
+        r"""
         Add value(values) from parallel process in sorted order
 
         Parameters
@@ -220,7 +220,7 @@ class BaseRegTest:
                 self._add_values(name, values, **kwargs)
 
     def par_add_sum(self, name, values, **kwargs):
-        """
+        r"""
         Add the sum of sum of the values from all processors.
 
         Parameters


### PR DESCRIPTION
## Purpose
Some incorrect escape sequences have been fixed, which raise warnings on import in certain conditions.

## Expected time until merged
A few days

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
None

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
