### PR TITLE
Remove mpi4py import on module import

### DIFF
--- a/baseclasses/__init__.py
+++ b/baseclasses/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.8.3"
+__version__ = "1.8.4"
 
 from .problems import (
     AeroProblem,

--- a/baseclasses/testing/pyRegTest.py
+++ b/baseclasses/testing/pyRegTest.py
@@ -73,6 +73,7 @@ class BaseRegTest:
         else:
             try:
                 from mpi4py import MPI
+
                 self.comm = MPI.COMM_WORLD
                 self.rank = self.comm.rank
             except ImportError:


### PR DESCRIPTION
## Purpose
This resolves a longstanding issue where any package that depends on baseclasses would import mpi4py if available, which can cause a lot of different side effects. This now wraps all those calls inside modules/functions so that it's only imported as necessary.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
